### PR TITLE
feat: adapt bindings to btck_api changes (including chain, blocktreeentries and serialization callbacks)

### DIFF
--- a/examples/src/silentpaymentscanner.rs
+++ b/examples/src/silentpaymentscanner.rs
@@ -162,13 +162,19 @@ fn scan_tx(receiver: &Receiver, secret_scan_key: &SecretKey, scan_tx_helper: Sca
 
 fn scan_txs(chainman: &ChainstateManager) {
     let (receiver, secret_scan_key) = parse_keys();
-    let mut block_index = chainman.block_index_tip();
+    let chain = chainman.active_chain();
+    let mut block_index = chain.tip();
+
     loop {
         if block_index.height() <= 1 {
             break;
         }
         let spent_outputs = chainman.read_spent_outputs(&block_index).unwrap();
-        let raw_block: Vec<u8> = chainman.read_block_data(&block_index).unwrap().into();
+        let raw_block: Vec<u8> = chainman
+            .read_block_data(&block_index)
+            .unwrap()
+            .try_into()
+            .unwrap();
         let block: bitcoin::Block = deserialize(&raw_block).unwrap();
         // Should be the same size minus the coinbase transaction
         assert_eq!(block.txdata.len() - 1, spent_outputs.count());

--- a/fuzz/fuzz_targets/fuzz_target_block.rs
+++ b/fuzz/fuzz_targets/fuzz_target_block.rs
@@ -5,7 +5,7 @@ use libfuzzer_sys::fuzz_target;
 
 fuzz_target!(|data: &[u8]| {
     if let Ok(block) = Block::try_from(data) {
-        let block_serialized: Vec<u8> = block.into();
+        let block_serialized: Vec<u8> = block.try_into().unwrap();
         assert!(data.len() >= block_serialized.len());
     }
 });

--- a/libbitcoinkernel-sys/bitcoin/src/test/kernel/test_kernel.cpp
+++ b/libbitcoinkernel-sys/bitcoin/src/test/kernel/test_kernel.cpp
@@ -43,19 +43,26 @@ std::string random_string(uint32_t length)
     return random;
 }
 
-std::vector<unsigned char> hex_string_to_char_vec(std::string_view hex)
+std::vector<std::byte> hex_string_to_byte_vec(std::string_view hex)
 {
-    std::vector<unsigned char> bytes;
+    std::vector<std::byte> bytes;
     bytes.reserve(hex.length() / 2);
 
     for (size_t i{0}; i < hex.length(); i += 2) {
-        unsigned char byte;
-        auto [ptr, ec] = std::from_chars(hex.data() + i, hex.data() + i + 2, byte, 16);
-        if (ec == std::errc{} && ptr == hex.data() + i + 2) {
-            bytes.push_back(byte);
+        uint8_t byte_value;
+        auto [ptr, ec] = std::from_chars(hex.data() + i, hex.data() + i + 2, byte_value, 16);
+
+        if (ec != std::errc{} || ptr != hex.data() + i + 2) {
+            throw std::invalid_argument("Invalid hex character");
         }
+        bytes.push_back(static_cast<std::byte>(byte_value));
     }
     return bytes;
+}
+
+std::span<const std::byte> as_bytes(std::vector<unsigned char> data)
+{
+    return std::span{reinterpret_cast<const std::byte*>(data.data()), data.size()};
 }
 
 constexpr auto VERIFY_ALL_PRE_SEGWIT{btck_SCRIPT_FLAGS_VERIFY_P2SH | btck_SCRIPT_FLAGS_VERIFY_DERSIG |
@@ -63,12 +70,13 @@ constexpr auto VERIFY_ALL_PRE_SEGWIT{btck_SCRIPT_FLAGS_VERIFY_P2SH | btck_SCRIPT
                                      btck_SCRIPT_FLAGS_VERIFY_CHECKSEQUENCEVERIFY};
 constexpr auto VERIFY_ALL_PRE_TAPROOT{VERIFY_ALL_PRE_SEGWIT | btck_SCRIPT_FLAGS_VERIFY_WITNESS};
 
-template<typename T, typename V>
-void check_equal(const T& actual, const V& expected) {
+void check_equal(std::span<const std::byte> _actual, std::span<const std::byte> _expected)
+{
+    std::span<const uint8_t> actual{reinterpret_cast<const unsigned char*>(_actual.data()), _actual.size()};
+    std::span<const uint8_t> expected{reinterpret_cast<const unsigned char*>(_expected.data()), _expected.size()};
     BOOST_CHECK_EQUAL_COLLECTIONS(
         actual.begin(), actual.end(),
-        expected.begin(), expected.end()
-    );
+        expected.begin(), expected.end());
 }
 
 class TestLog
@@ -128,14 +136,14 @@ class TestValidationInterface : public ValidationInterface<TestValidationInterfa
 public:
     TestValidationInterface() : ValidationInterface() {}
 
-    std::optional<std::vector<unsigned char>> m_expected_valid_block = std::nullopt;
+    std::optional<std::vector<std::byte>> m_expected_valid_block = std::nullopt;
 
     void BlockChecked(const UnownedBlock block, const BlockValidationState state) override
     {
         {
-            auto serialized_block{block.GetBlockData()};
+            auto ser_block{block.ToBytes()};
             if (m_expected_valid_block.has_value()) {
-                check_equal(m_expected_valid_block.value(),serialized_block);
+                check_equal(m_expected_valid_block.value(), ser_block);
             }
         }
 
@@ -250,21 +258,24 @@ void run_verify_test(
 
 BOOST_AUTO_TEST_CASE(btck_transaction_tests)
 {
-    auto tx_data{hex_string_to_char_vec("02000000013f7cebd65c27431a90bba7f796914fe8cc2ddfc3f2cbd6f7e5f2fc854534da95000000006b483045022100de1ac3bcdfb0332207c4a91f3832bd2c2915840165f876ab47c5f8996b971c3602201c6c053d750fadde599e6f5c4e1963df0f01fc0d97815e8157e3d59fe09ca30d012103699b464d1d8bc9e47d4fb1cdaa89a1c5783d68363c4dbc4b524ed3d857148617feffffff02836d3c01000000001976a914fc25d6d5c94003bf5b0c7b640a248e2c637fcfb088ac7ada8202000000001976a914fbed3d9b11183209a57999d54d59f67c019e756c88ac6acb0700")};
+    auto tx_data{hex_string_to_byte_vec("02000000013f7cebd65c27431a90bba7f796914fe8cc2ddfc3f2cbd6f7e5f2fc854534da95000000006b483045022100de1ac3bcdfb0332207c4a91f3832bd2c2915840165f876ab47c5f8996b971c3602201c6c053d750fadde599e6f5c4e1963df0f01fc0d97815e8157e3d59fe09ca30d012103699b464d1d8bc9e47d4fb1cdaa89a1c5783d68363c4dbc4b524ed3d857148617feffffff02836d3c01000000001976a914fc25d6d5c94003bf5b0c7b640a248e2c637fcfb088ac7ada8202000000001976a914fbed3d9b11183209a57999d54d59f67c019e756c88ac6acb0700")};
     auto tx{Transaction{tx_data}};
     BOOST_CHECK_EQUAL(tx.CountOutputs(), 2);
     BOOST_CHECK_EQUAL(tx.CountInputs(), 1);
-    auto broken_tx_data{std::span<unsigned char>{tx_data.begin(), tx_data.begin() + 10}};
+    auto broken_tx_data{std::span<std::byte>{tx_data.begin(), tx_data.begin() + 10}};
     BOOST_CHECK_THROW(Transaction{broken_tx_data}, std::runtime_error);
     auto output{tx.GetOutput(tx.CountOutputs() - 1)};
     BOOST_CHECK_EQUAL(output.Get().GetAmount(), 42130042);
     auto script_pubkey{output.Get().GetScriptPubkey()};
     {
         auto tx_new{Transaction{tx_data}};
-        // This is safe, becaause we now use copy assignment
+        // This is safe, because we now use copy assignment
         TransactionOutput output = tx_new.GetOutput(tx_new.CountOutputs() - 1).Get();
     }
     BOOST_CHECK_EQUAL(output.Get().GetAmount(), 42130042);
+
+    auto tx_roundtrip{Transaction{tx.ToBytes()}};
+    check_equal(tx_roundtrip.ToBytes(), tx_data);
 
     // The following code is unsafe, but left here to show limitations of the
     // API, because we RVO-move the output beyond the lifetime of the
@@ -275,14 +286,17 @@ BOOST_AUTO_TEST_CASE(btck_transaction_tests)
     };
     auto output_new = get_output();
     BOOST_CHECK_EQUAL(output_new.Get().GetAmount(), 20737411);
+
+    ScriptPubkey script_pubkey_roundtrip{script_pubkey.Get().ToBytes()};
+    check_equal(script_pubkey_roundtrip.ToBytes(), script_pubkey.Get().ToBytes());
 }
 
 BOOST_AUTO_TEST_CASE(btck_script_verify_tests)
 {
     // Legacy transaction aca326a724eda9a461c10a876534ecd5ae7b27f10f26c3862fb996f80ea2d45d
     run_verify_test(
-        /*spent_script_pubkey*/ ScriptPubkey{hex_string_to_char_vec("76a9144bfbaf6afb76cc5771bc6404810d1cc041a6933988ac")},
-        /*spending_tx*/ Transaction{hex_string_to_char_vec("02000000013f7cebd65c27431a90bba7f796914fe8cc2ddfc3f2cbd6f7e5f2fc854534da95000000006b483045022100de1ac3bcdfb0332207c4a91f3832bd2c2915840165f876ab47c5f8996b971c3602201c6c053d750fadde599e6f5c4e1963df0f01fc0d97815e8157e3d59fe09ca30d012103699b464d1d8bc9e47d4fb1cdaa89a1c5783d68363c4dbc4b524ed3d857148617feffffff02836d3c01000000001976a914fc25d6d5c94003bf5b0c7b640a248e2c637fcfb088ac7ada8202000000001976a914fbed3d9b11183209a57999d54d59f67c019e756c88ac6acb0700")},
+        /*spent_script_pubkey*/ ScriptPubkey{hex_string_to_byte_vec("76a9144bfbaf6afb76cc5771bc6404810d1cc041a6933988ac")},
+        /*spending_tx*/ Transaction{hex_string_to_byte_vec("02000000013f7cebd65c27431a90bba7f796914fe8cc2ddfc3f2cbd6f7e5f2fc854534da95000000006b483045022100de1ac3bcdfb0332207c4a91f3832bd2c2915840165f876ab47c5f8996b971c3602201c6c053d750fadde599e6f5c4e1963df0f01fc0d97815e8157e3d59fe09ca30d012103699b464d1d8bc9e47d4fb1cdaa89a1c5783d68363c4dbc4b524ed3d857148617feffffff02836d3c01000000001976a914fc25d6d5c94003bf5b0c7b640a248e2c637fcfb088ac7ada8202000000001976a914fbed3d9b11183209a57999d54d59f67c019e756c88ac6acb0700")},
         /*spent_outputs*/ {},
         /*amount*/ 0,
         /*input_index*/ 0,
@@ -290,20 +304,20 @@ BOOST_AUTO_TEST_CASE(btck_script_verify_tests)
 
     // Segwit transaction 1a3e89644985fbbb41e0dcfe176739813542b5937003c46a07de1e3ee7a4a7f3
     run_verify_test(
-        /*spent_script_pubkey*/ ScriptPubkey{hex_string_to_char_vec("0020701a8d401c84fb13e6baf169d59684e17abd9fa216c8cc5b9fc63d622ff8c58d")},
-        /*spending_tx*/ Transaction{hex_string_to_char_vec("010000000001011f97548fbbe7a0db7588a66e18d803d0089315aa7d4cc28360b6ec50ef36718a0100000000ffffffff02df1776000000000017a9146c002a686959067f4866b8fb493ad7970290ab728757d29f0000000000220020701a8d401c84fb13e6baf169d59684e17abd9fa216c8cc5b9fc63d622ff8c58d04004730440220565d170eed95ff95027a69b313758450ba84a01224e1f7f130dda46e94d13f8602207bdd20e307f062594022f12ed5017bbf4a055a06aea91c10110a0e3bb23117fc014730440220647d2dc5b15f60bc37dc42618a370b2a1490293f9e5c8464f53ec4fe1dfe067302203598773895b4b16d37485cbe21b337f4e4b650739880098c592553add7dd4355016952210375e00eb72e29da82b89367947f29ef34afb75e8654f6ea368e0acdfd92976b7c2103a1b26313f430c4b15bb1fdce663207659d8cac749a0e53d70eff01874496feff2103c96d495bfdd5ba4145e3e046fee45e84a8a48ad05bd8dbb395c011a32cf9f88053ae00000000")},
+        /*spent_script_pubkey*/ ScriptPubkey{hex_string_to_byte_vec("0020701a8d401c84fb13e6baf169d59684e17abd9fa216c8cc5b9fc63d622ff8c58d")},
+        /*spending_tx*/ Transaction{hex_string_to_byte_vec("010000000001011f97548fbbe7a0db7588a66e18d803d0089315aa7d4cc28360b6ec50ef36718a0100000000ffffffff02df1776000000000017a9146c002a686959067f4866b8fb493ad7970290ab728757d29f0000000000220020701a8d401c84fb13e6baf169d59684e17abd9fa216c8cc5b9fc63d622ff8c58d04004730440220565d170eed95ff95027a69b313758450ba84a01224e1f7f130dda46e94d13f8602207bdd20e307f062594022f12ed5017bbf4a055a06aea91c10110a0e3bb23117fc014730440220647d2dc5b15f60bc37dc42618a370b2a1490293f9e5c8464f53ec4fe1dfe067302203598773895b4b16d37485cbe21b337f4e4b650739880098c592553add7dd4355016952210375e00eb72e29da82b89367947f29ef34afb75e8654f6ea368e0acdfd92976b7c2103a1b26313f430c4b15bb1fdce663207659d8cac749a0e53d70eff01874496feff2103c96d495bfdd5ba4145e3e046fee45e84a8a48ad05bd8dbb395c011a32cf9f88053ae00000000")},
         /*spent_outputs*/ {},
         /*amount*/ 18393430,
         /*input_index*/ 0,
         /*is_taproot*/ false);
 
     // Taproot transaction 33e794d097969002ee05d336686fc03c9e15a597c1b9827669460fac98799036
-    auto taproot_spent_script_pubkey{ScriptPubkey{hex_string_to_char_vec("5120339ce7e165e67d93adb3fef88a6d4beed33f01fa876f05a225242b82a631abc0")}};
+    auto taproot_spent_script_pubkey{ScriptPubkey{hex_string_to_byte_vec("5120339ce7e165e67d93adb3fef88a6d4beed33f01fa876f05a225242b82a631abc0")}};
     std::vector<TransactionOutput> spent_outputs;
     spent_outputs.emplace_back(taproot_spent_script_pubkey, 88480);
     run_verify_test(
         /*spent_script_pubkey*/ taproot_spent_script_pubkey,
-        /*spending_tx*/ Transaction{hex_string_to_char_vec("01000000000101d1f1c1f8cdf6759167b90f52c9ad358a369f95284e841d7a2536cef31c0549580100000000fdffffff020000000000000000316a2f49206c696b65205363686e6f7272207369677320616e6420492063616e6e6f74206c69652e204062697462756734329e06010000000000225120a37c3903c8d0db6512e2b40b0dffa05e5a3ab73603ce8c9c4b7771e5412328f90140a60c383f71bac0ec919b1d7dbc3eb72dd56e7aa99583615564f9f99b8ae4e837b758773a5b2e4c51348854c8389f008e05029db7f464a5ff2e01d5e6e626174affd30a00")},
+        /*spending_tx*/ Transaction{hex_string_to_byte_vec("01000000000101d1f1c1f8cdf6759167b90f52c9ad358a369f95284e841d7a2536cef31c0549580100000000fdffffff020000000000000000316a2f49206c696b65205363686e6f7272207369677320616e6420492063616e6e6f74206c69652e204062697462756734329e06010000000000225120a37c3903c8d0db6512e2b40b0dffa05e5a3ab73603ce8c9c4b7771e5412328f90140a60c383f71bac0ec919b1d7dbc3eb72dd56e7aa99583615564f9f99b8ae4e837b758773a5b2e4c51348854c8389f008e05029db7f464a5ff2e01d5e6e626174affd30a00")},
         /*spent_outputs*/ spent_outputs,
         /*amount*/ 88480,
         /*input_index*/ 0,
@@ -442,28 +456,30 @@ void chainman_reindex_test(TestDirectory& test_directory)
     BOOST_CHECK(chainman->ImportBlocks(import_files));
 
     // Sanity check some block retrievals
-    auto genesis_index{chainman->GetBlockIndexFromGenesis()};
-    auto genesis_block_raw{chainman->ReadBlock(genesis_index).value().GetBlockData()};
-    auto first_index{chainman->GetBlockIndexByHeight(0).value()};
-    auto first_block_raw{chainman->ReadBlock(genesis_index).value().GetBlockData()};
+    auto chain{chainman->GetChain()};
+    auto genesis_index{chain.Get().GetGenesis()};
+    auto genesis_block_raw{chainman->ReadBlock(genesis_index).value().ToBytes()};
+    auto first_index{chain.Get().GetByHeight(0).value()};
+    auto first_block_raw{chainman->ReadBlock(genesis_index).value().ToBytes()};
     check_equal(genesis_block_raw, first_block_raw);
     auto height{first_index.GetHeight()};
     BOOST_CHECK_EQUAL(height, 0);
 
-    auto next_index{chainman->GetNextBlockIndex(first_index).value()};
-    auto next_block_data{chainman->ReadBlock(next_index).value().GetBlockData()};
-    auto tip_index{chainman->GetBlockIndexFromTip()};
-    auto tip_block_data{chainman->ReadBlock(tip_index).value().GetBlockData()};
-    auto second_index{chainman->GetBlockIndexByHeight(1).value()};
+    auto next_index{chain.Get().GetNextBlockTreeEntry(first_index).value()};
+    BOOST_CHECK(chain.Get().Contains(next_index));
+    auto next_block_data{chainman->ReadBlock(next_index).value().ToBytes()};
+    auto tip_index{chain.Get().GetTip()};
+    auto tip_block_data{chainman->ReadBlock(tip_index).value().ToBytes()};
+    auto second_index{chain.Get().GetByHeight(1).value()};
     auto second_block{chainman->ReadBlock(second_index).value()};
-    auto second_block_data{second_block.GetBlockData()};
+    auto second_block_data{second_block.ToBytes()};
     auto second_height{second_index.GetHeight()};
     BOOST_CHECK_EQUAL(second_height, 1);
     check_equal(next_block_data, tip_block_data);
     check_equal(next_block_data, second_block_data);
 
     auto hash{second_index.GetHash()};
-    auto another_second_index{chainman->GetBlockIndexByHash(hash.get())};
+    auto another_second_index{chainman->GetBlockTreeEntry(hash.get())};
     auto another_second_height{another_second_index.GetHeight()};
     auto block_hash{second_block.GetHash()};
     BOOST_CHECK(std::equal(std::begin(block_hash->hash), std::end(block_hash->hash), std::begin(hash->hash)));
@@ -490,37 +506,39 @@ void chainman_mainnet_validation_test(TestDirectory& test_directory)
 
     {
         // Process an invalid block
-        auto raw_block = hex_string_to_char_vec("012300");
+        auto raw_block = hex_string_to_byte_vec("012300");
         BOOST_CHECK_THROW(Block{raw_block}, std::runtime_error);
     }
     {
         // Process an empty block
-        auto raw_block = hex_string_to_char_vec("");
+        auto raw_block = hex_string_to_byte_vec("");
         BOOST_CHECK_THROW(Block{raw_block}, std::runtime_error);
     }
 
     // mainnet block 1
-    auto raw_block = hex_string_to_char_vec("010000006fe28c0ab6f1b372c1a6a246ae63f74f931e8365e15a089c68d6190000000000982051fd1e4ba744bbbe680e1fee14677ba1a3c3540bf7b1cdb606e857233e0e61bc6649ffff001d01e362990101000000010000000000000000000000000000000000000000000000000000000000000000ffffffff0704ffff001d0104ffffffff0100f2052a0100000043410496b538e853519c726a2c91e61ec11600ae1390813a627c66fb8be7947be63c52da7589379515d4e0a604f8141781e62294721166bf621e73a82cbf2342c858eeac00000000");
+    auto raw_block = hex_string_to_byte_vec("010000006fe28c0ab6f1b372c1a6a246ae63f74f931e8365e15a089c68d6190000000000982051fd1e4ba744bbbe680e1fee14677ba1a3c3540bf7b1cdb606e857233e0e61bc6649ffff001d01e362990101000000010000000000000000000000000000000000000000000000000000000000000000ffffffff0704ffff001d0104ffffffff0100f2052a0100000043410496b538e853519c726a2c91e61ec11600ae1390813a627c66fb8be7947be63c52da7589379515d4e0a604f8141781e62294721166bf621e73a82cbf2342c858eeac00000000");
     Block block{raw_block};
     Transaction tx{block.GetTransaction(block.CountOutputs() - 1)};
 
     validation_interface.m_expected_valid_block.emplace(raw_block);
-    check_equal(block.GetBlockData(), raw_block);
+    auto ser_block{block.ToBytes()};
+    check_equal(ser_block, raw_block);
     bool new_block = false;
     BOOST_CHECK(chainman->ProcessBlock(block, &new_block));
     BOOST_CHECK(new_block);
 
-    auto tip{chainman->GetBlockIndexFromTip()};
+    auto chain{chainman->GetChain()};
+    auto tip{chain.Get().GetTip()};
     auto read_block{chainman->ReadBlock(tip)};
     BOOST_REQUIRE(read_block);
-    check_equal(read_block.value().GetBlockData(), raw_block);
+    check_equal(read_block.value().ToBytes(), raw_block);
 
     // Check that we can read the previous block
-    auto tip_2{tip.GetPreviousBlockIndex()};
+    auto tip_2{tip.GetPrevious()};
     auto read_block_2{chainman->ReadBlock(tip_2.value())};
 
     // It should be an error if we go another block back, since the genesis has no ancestor
-    BOOST_CHECK(!tip_2.value().GetPreviousBlockIndex());
+    BOOST_CHECK(!tip_2.value().GetPrevious());
 
     // If we try to validate it again, it should be a duplicate
     BOOST_CHECK(chainman->ProcessBlock(block, &new_block));
@@ -553,7 +571,7 @@ BOOST_AUTO_TEST_CASE(btck_chainman_in_memory_tests)
     auto chainman{create_chainman(in_memory_test_directory, false, false, true, true, context)};
 
     for (auto& raw_block : REGTEST_BLOCK_DATA) {
-        Block block{raw_block};
+        Block block{as_bytes(raw_block)};
         bool new_block{false};
         chainman->ProcessBlock(block, &new_block);
         BOOST_CHECK(new_block);
@@ -578,7 +596,7 @@ BOOST_AUTO_TEST_CASE(btck_chainman_regtest_tests)
     {
         auto chainman{create_chainman(test_directory, false, false, false, false, context)};
         for (size_t i{0}; i < mid; i++) {
-            Block block{REGTEST_BLOCK_DATA[i]};
+            Block block{as_bytes(REGTEST_BLOCK_DATA[i])};
             bool new_block{false};
             BOOST_CHECK(chainman->ProcessBlock(block, &new_block));
             BOOST_CHECK(new_block);
@@ -588,19 +606,20 @@ BOOST_AUTO_TEST_CASE(btck_chainman_regtest_tests)
     auto chainman{create_chainman(test_directory, false, false, false, false, context)};
 
     for (size_t i{mid}; i < REGTEST_BLOCK_DATA.size(); i++) {
-        Block block{REGTEST_BLOCK_DATA[i]};
+        Block block{as_bytes(REGTEST_BLOCK_DATA[i])};
         bool new_block{false};
         BOOST_CHECK(chainman->ProcessBlock(block, &new_block));
         BOOST_CHECK(new_block);
     }
 
-    auto tip = chainman->GetBlockIndexFromTip();
+    auto chain = chainman->GetChain();
+    auto tip = chain.Get().GetTip();
     auto read_block = chainman->ReadBlock(tip).value();
-    check_equal(read_block.GetBlockData(), REGTEST_BLOCK_DATA[REGTEST_BLOCK_DATA.size() - 1]);
+    check_equal(read_block.ToBytes(), as_bytes(REGTEST_BLOCK_DATA[REGTEST_BLOCK_DATA.size() - 1]));
 
-    auto tip_2 = tip.GetPreviousBlockIndex().value();
+    auto tip_2 = tip.GetPrevious().value();
     auto read_block_2 = chainman->ReadBlock(tip_2).value();
-    check_equal(read_block_2.GetBlockData(), REGTEST_BLOCK_DATA[REGTEST_BLOCK_DATA.size() - 2]);
+    check_equal(read_block_2.ToBytes(), as_bytes(REGTEST_BLOCK_DATA[REGTEST_BLOCK_DATA.size() - 2]));
 
     BlockSpentOutputs block_spent_outputs{chainman->ReadBlockSpentOutputs(tip)};
     BOOST_CHECK_EQUAL(block_spent_outputs.m_size, 1);
@@ -611,7 +630,10 @@ BOOST_AUTO_TEST_CASE(btck_chainman_regtest_tests)
     BOOST_CHECK_EQUAL(coin_height, 205);
     BOOST_CHECK_EQUAL(output.Get().GetAmount(), 100000000);
     auto script_pubkey = output.Get().GetScriptPubkey();
-    BOOST_CHECK_EQUAL(script_pubkey.Get().GetScriptPubkeyData().size(), 22);
+    auto script_pubkey_bytes{script_pubkey.Get().ToBytes()};
+    BOOST_CHECK_EQUAL(script_pubkey_bytes.size(), 22);
+    auto round_trip_script_pubkey{ScriptPubkey(script_pubkey_bytes)};
+    BOOST_CHECK_EQUAL(round_trip_script_pubkey.ToBytes().size(), 22);
 
     // Test that reading past the size returns null data
     // BOOST_CHECK_THROW(block_spent_outputs.GetTxSpentOutputs(block_spent_outputs.m_size), std::runtime_error);


### PR DESCRIPTION
# Adapt bindings to btck_api changes

This PR updates the rust-bitcoinkernel bindings to work with btck_api on commit 38600fcc1bdfda7043973a4e65d53e174fbf7249
https://github.com/TheCharlatan/bitcoin/tree/kernelApi_56

## Changes

- **Rename BlockIndex to BlockTreeIndex**: Updated type name to match the new btck_api naming convention
- **Add Chain instance**: Introduces the Chain instance type
- **Introduce c_helpers module**: Adds a new module containing helper functions for converting between Rust and C types
- **Implement serialization through callbacks**: Added callback-based serialization mechanism
- **Rename `to_bytes` to `consensus_encode` where relevant**: Updated method names on relevant types to distinguish between operations

## Next Steps

- Breaking up the files to not just a lib.rs file
- Unit testing
- Fuzz testing for the chain
- Implementing further changes from the C API, specifically enums
- Adding backward iteration through the chain instance
- Implementing traits for commonly used methods on types