### PR TITLE
Fix(ffi): introduce sealed traits for internal FFI pointer management

### DIFF
--- a/src/core/block.rs
+++ b/src/core/block.rs
@@ -12,7 +12,7 @@ use libbitcoinkernel_sys::{
     btck_transaction_spent_outputs_get_coin_at,
 };
 
-use crate::{c_helpers, c_serialize, KernelError};
+use crate::{c_helpers, c_serialize, ffi::sealed::AsPtr, KernelError};
 
 use super::transaction::{TransactionRef, TxOutRef};
 
@@ -90,8 +90,10 @@ impl Block {
             btck_block_to_bytes(self.inner, Some(callback), user_data)
         })
     }
+}
 
-    pub fn as_ptr(&self) -> *const btck_Block {
+impl AsPtr<btck_Block> for Block {
+    fn as_ptr(&self) -> *const btck_Block {
         self.inner as *const _
     }
 }
@@ -135,10 +137,7 @@ impl TryFrom<&Block> for Vec<u8> {
 }
 
 /// Common operations for block spent outputs, implemented by both owned and borrowed types.
-pub trait BlockSpentOutputsExt {
-    /// Returns a raw pointer to the underlying C object.
-    fn as_ptr(&self) -> *const btck_BlockSpentOutputs;
-
+pub trait BlockSpentOutputsExt: AsPtr<btck_BlockSpentOutputs> {
     /// Returns the number of transactions that have spent output data.
     ///
     /// Note: This excludes the coinbase transaction, which has no inputs.
@@ -196,11 +195,13 @@ impl BlockSpentOutputs {
     }
 }
 
-impl BlockSpentOutputsExt for BlockSpentOutputs {
+impl AsPtr<btck_BlockSpentOutputs> for BlockSpentOutputs {
     fn as_ptr(&self) -> *const btck_BlockSpentOutputs {
         self.inner as *const _
     }
 }
+
+impl BlockSpentOutputsExt for BlockSpentOutputs {}
 
 impl Clone for BlockSpentOutputs {
     fn clone(&self) -> Self {
@@ -236,11 +237,13 @@ impl<'a> BlockSpentOutputsRef<'a> {
     }
 }
 
-impl<'a> BlockSpentOutputsExt for BlockSpentOutputsRef<'a> {
+impl<'a> AsPtr<btck_BlockSpentOutputs> for BlockSpentOutputsRef<'a> {
     fn as_ptr(&self) -> *const btck_BlockSpentOutputs {
         self.inner
     }
 }
+
+impl<'a> BlockSpentOutputsExt for BlockSpentOutputsRef<'a> {}
 
 impl<'a> Clone for BlockSpentOutputsRef<'a> {
     fn clone(&self) -> Self {
@@ -251,10 +254,7 @@ impl<'a> Clone for BlockSpentOutputsRef<'a> {
 impl<'a> Copy for BlockSpentOutputsRef<'a> {}
 
 /// Common operations for transaction spent outputs, implemented by both owned and borrowed types.
-pub trait TransactionSpentOutputsExt {
-    /// Returns a raw pointer to the underlying C object.
-    fn as_ptr(&self) -> *const btck_TransactionSpentOutputs;
-
+pub trait TransactionSpentOutputsExt: AsPtr<btck_TransactionSpentOutputs> {
     /// Returns the number of coins spent by this transaction
     fn count(&self) -> usize {
         unsafe { btck_transaction_spent_outputs_count(self.as_ptr()) }
@@ -296,11 +296,13 @@ impl TransactionSpentOutputs {
     }
 }
 
-impl TransactionSpentOutputsExt for TransactionSpentOutputs {
+impl AsPtr<btck_TransactionSpentOutputs> for TransactionSpentOutputs {
     fn as_ptr(&self) -> *const btck_TransactionSpentOutputs {
         self.inner as *const _
     }
 }
+
+impl TransactionSpentOutputsExt for TransactionSpentOutputs {}
 
 impl Clone for TransactionSpentOutputs {
     fn clone(&self) -> Self {
@@ -336,11 +338,13 @@ impl<'a> TransactionSpentOutputsRef<'a> {
     }
 }
 
-impl<'a> TransactionSpentOutputsExt for TransactionSpentOutputsRef<'a> {
+impl<'a> AsPtr<btck_TransactionSpentOutputs> for TransactionSpentOutputsRef<'a> {
     fn as_ptr(&self) -> *const btck_TransactionSpentOutputs {
         self.inner
     }
 }
+
+impl<'a> TransactionSpentOutputsExt for TransactionSpentOutputsRef<'a> {}
 
 impl<'a> Clone for TransactionSpentOutputsRef<'a> {
     fn clone(&self) -> Self {
@@ -351,10 +355,7 @@ impl<'a> Clone for TransactionSpentOutputsRef<'a> {
 impl<'a> Copy for TransactionSpentOutputsRef<'a> {}
 
 /// Common operations for coins, implemented by both owned and borrowed types.
-pub trait CoinExt {
-    /// Returns a raw pointer to the underlying C object.
-    fn as_ptr(&self) -> *const btck_Coin;
-
+pub trait CoinExt: AsPtr<btck_Coin> {
     /// Returns the height of the block where this coin was created.
     fn confirmation_height(&self) -> u32 {
         unsafe { btck_coin_confirmation_height(self.as_ptr()) }
@@ -395,11 +396,13 @@ impl Coin {
     }
 }
 
-impl CoinExt for Coin {
+impl AsPtr<btck_Coin> for Coin {
     fn as_ptr(&self) -> *const btck_Coin {
         self.inner as *const _
     }
 }
+
+impl CoinExt for Coin {}
 
 impl Clone for Coin {
     fn clone(&self) -> Self {
@@ -435,11 +438,13 @@ impl<'a> CoinRef<'a> {
     }
 }
 
-impl<'a> CoinExt for CoinRef<'a> {
+impl<'a> AsPtr<btck_Coin> for CoinRef<'a> {
     fn as_ptr(&self) -> *const btck_Coin {
         self.inner
     }
 }
+
+impl<'a> CoinExt for CoinRef<'a> {}
 
 impl<'a> Clone for CoinRef<'a> {
     fn clone(&self) -> Self {

--- a/src/core/block.rs
+++ b/src/core/block.rs
@@ -12,7 +12,11 @@ use libbitcoinkernel_sys::{
     btck_transaction_spent_outputs_get_coin_at,
 };
 
-use crate::{c_helpers, c_serialize, ffi::sealed::AsPtr, KernelError};
+use crate::{
+    c_helpers, c_serialize,
+    ffi::sealed::{AsPtr, FromMutPtr, FromPtr},
+    KernelError,
+};
 
 use super::transaction::{TransactionRef, TxOutRef};
 
@@ -34,10 +38,6 @@ unsafe impl Send for Block {}
 unsafe impl Sync for Block {}
 
 impl Block {
-    pub unsafe fn from_ptr(ptr: *mut btck_Block) -> Self {
-        Block { inner: ptr }
-    }
-
     pub fn new(raw_block: &[u8]) -> Result<Self, KernelError> {
         let inner =
             unsafe { btck_block_create(raw_block.as_ptr() as *const c_void, raw_block.len()) };
@@ -95,6 +95,12 @@ impl Block {
 impl AsPtr<btck_Block> for Block {
     fn as_ptr(&self) -> *const btck_Block {
         self.inner as *const _
+    }
+}
+
+impl FromMutPtr<btck_Block> for Block {
+    unsafe fn from_ptr(ptr: *mut btck_Block) -> Self {
+        Block { inner: ptr }
     }
 }
 
@@ -186,12 +192,14 @@ unsafe impl Send for BlockSpentOutputs {}
 unsafe impl Sync for BlockSpentOutputs {}
 
 impl BlockSpentOutputs {
-    pub unsafe fn from_ptr(ptr: *mut btck_BlockSpentOutputs) -> Self {
-        BlockSpentOutputs { inner: ptr }
-    }
-
     pub fn as_ref(&self) -> BlockSpentOutputsRef<'_> {
         unsafe { BlockSpentOutputsRef::from_ptr(self.inner as *const _) }
+    }
+}
+
+impl FromMutPtr<btck_BlockSpentOutputs> for BlockSpentOutputs {
+    unsafe fn from_ptr(ptr: *mut btck_BlockSpentOutputs) -> Self {
+        BlockSpentOutputs { inner: ptr }
     }
 }
 
@@ -223,13 +231,6 @@ pub struct BlockSpentOutputsRef<'a> {
 }
 
 impl<'a> BlockSpentOutputsRef<'a> {
-    pub unsafe fn from_ptr(ptr: *const btck_BlockSpentOutputs) -> Self {
-        BlockSpentOutputsRef {
-            inner: ptr,
-            marker: PhantomData,
-        }
-    }
-
     pub fn to_owned(&self) -> BlockSpentOutputs {
         BlockSpentOutputs {
             inner: unsafe { btck_block_spent_outputs_copy(self.inner) },
@@ -240,6 +241,15 @@ impl<'a> BlockSpentOutputsRef<'a> {
 impl<'a> AsPtr<btck_BlockSpentOutputs> for BlockSpentOutputsRef<'a> {
     fn as_ptr(&self) -> *const btck_BlockSpentOutputs {
         self.inner
+    }
+}
+
+impl<'a> FromPtr<btck_BlockSpentOutputs> for BlockSpentOutputsRef<'a> {
+    unsafe fn from_ptr(ptr: *const btck_BlockSpentOutputs) -> Self {
+        BlockSpentOutputsRef {
+            inner: ptr,
+            marker: PhantomData,
+        }
     }
 }
 
@@ -324,13 +334,6 @@ pub struct TransactionSpentOutputsRef<'a> {
 }
 
 impl<'a> TransactionSpentOutputsRef<'a> {
-    pub unsafe fn from_ptr(ptr: *const btck_TransactionSpentOutputs) -> Self {
-        TransactionSpentOutputsRef {
-            inner: ptr,
-            marker: PhantomData,
-        }
-    }
-
     pub fn to_owned(&self) -> TransactionSpentOutputs {
         TransactionSpentOutputs {
             inner: unsafe { btck_transaction_spent_outputs_copy(self.inner) },
@@ -341,6 +344,15 @@ impl<'a> TransactionSpentOutputsRef<'a> {
 impl<'a> AsPtr<btck_TransactionSpentOutputs> for TransactionSpentOutputsRef<'a> {
     fn as_ptr(&self) -> *const btck_TransactionSpentOutputs {
         self.inner
+    }
+}
+
+impl<'a> FromPtr<btck_TransactionSpentOutputs> for TransactionSpentOutputsRef<'a> {
+    unsafe fn from_ptr(ptr: *const btck_TransactionSpentOutputs) -> Self {
+        TransactionSpentOutputsRef {
+            inner: ptr,
+            marker: PhantomData,
+        }
     }
 }
 
@@ -424,13 +436,6 @@ pub struct CoinRef<'a> {
 }
 
 impl<'a> CoinRef<'a> {
-    pub unsafe fn from_ptr(ptr: *const btck_Coin) -> Self {
-        CoinRef {
-            inner: ptr,
-            marker: PhantomData,
-        }
-    }
-
     pub fn to_owned(&self) -> Coin {
         Coin {
             inner: unsafe { btck_coin_copy(self.inner) },
@@ -441,6 +446,15 @@ impl<'a> CoinRef<'a> {
 impl<'a> AsPtr<btck_Coin> for CoinRef<'a> {
     fn as_ptr(&self) -> *const btck_Coin {
         self.inner
+    }
+}
+
+impl<'a> FromPtr<btck_Coin> for CoinRef<'a> {
+    unsafe fn from_ptr(ptr: *const btck_Coin) -> Self {
+        CoinRef {
+            inner: ptr,
+            marker: PhantomData,
+        }
     }
 }
 

--- a/src/core/block_tree_entry.rs
+++ b/src/core/block_tree_entry.rs
@@ -5,7 +5,10 @@ use libbitcoinkernel_sys::{
     btck_block_tree_entry_get_height, btck_block_tree_entry_get_previous,
 };
 
-use crate::{ffi::sealed::AsPtr, BlockHash, ChainstateManager};
+use crate::{
+    ffi::sealed::{AsPtr, FromPtr},
+    BlockHash, ChainstateManager,
+};
 
 /// A block tree entry that is tied to a specific [`ChainstateManager`].
 ///
@@ -23,13 +26,6 @@ unsafe impl Send for BlockTreeEntry<'_> {}
 unsafe impl Sync for BlockTreeEntry<'_> {}
 
 impl<'a> BlockTreeEntry<'a> {
-    pub unsafe fn from_ptr(ptr: *const btck_BlockTreeEntry) -> Self {
-        BlockTreeEntry {
-            inner: ptr,
-            marker: PhantomData,
-        }
-    }
-
     /// Move to the previous entry in the block tree. E.g. from height n to
     /// height n-1.
     pub fn prev(self) -> Option<BlockTreeEntry<'a>> {
@@ -61,6 +57,15 @@ impl<'a> BlockTreeEntry<'a> {
 impl<'a> AsPtr<btck_BlockTreeEntry> for BlockTreeEntry<'a> {
     fn as_ptr(&self) -> *const btck_BlockTreeEntry {
         self.inner
+    }
+}
+
+impl<'a> FromPtr<btck_BlockTreeEntry> for BlockTreeEntry<'a> {
+    unsafe fn from_ptr(ptr: *const btck_BlockTreeEntry) -> Self {
+        BlockTreeEntry {
+            inner: ptr,
+            marker: PhantomData,
+        }
     }
 }
 

--- a/src/core/block_tree_entry.rs
+++ b/src/core/block_tree_entry.rs
@@ -5,7 +5,7 @@ use libbitcoinkernel_sys::{
     btck_block_tree_entry_get_height, btck_block_tree_entry_get_previous,
 };
 
-use crate::{BlockHash, ChainstateManager};
+use crate::{ffi::sealed::AsPtr, BlockHash, ChainstateManager};
 
 /// A block tree entry that is tied to a specific [`ChainstateManager`].
 ///
@@ -56,8 +56,10 @@ impl<'a> BlockTreeEntry<'a> {
         unsafe { btck_block_hash_destroy(hash) };
         res
     }
+}
 
-    pub fn as_ptr(&self) -> *const btck_BlockTreeEntry {
+impl<'a> AsPtr<btck_BlockTreeEntry> for BlockTreeEntry<'a> {
+    fn as_ptr(&self) -> *const btck_BlockTreeEntry {
         self.inner
     }
 }

--- a/src/core/script.rs
+++ b/src/core/script.rs
@@ -5,13 +5,10 @@ use libbitcoinkernel_sys::{
     btck_script_pubkey_destroy, btck_script_pubkey_to_bytes,
 };
 
-use crate::{c_serialize, KernelError};
+use crate::{c_serialize, ffi::sealed::AsPtr, KernelError};
 
 /// Common operations for script pubkeys, implemented by both owned and borrowed types.
-pub trait ScriptPubkeyExt {
-    /// Returns a raw pointer to the underlying C object.
-    fn as_ptr(&self) -> *const btck_ScriptPubkey;
-
+pub trait ScriptPubkeyExt: AsPtr<btck_ScriptPubkey> {
     /// Serializes the script to raw bytes.
     fn to_bytes(&self) -> Vec<u8> {
         c_serialize(|callback, user_data| unsafe {
@@ -53,11 +50,13 @@ impl ScriptPubkey {
     }
 }
 
-impl ScriptPubkeyExt for ScriptPubkey {
+impl AsPtr<btck_ScriptPubkey> for ScriptPubkey {
     fn as_ptr(&self) -> *const btck_ScriptPubkey {
         self.inner as *const _
     }
 }
+
+impl ScriptPubkeyExt for ScriptPubkey {}
 
 impl Clone for ScriptPubkey {
     fn clone(&self) -> Self {
@@ -113,11 +112,13 @@ impl<'a> ScriptPubkeyRef<'a> {
     }
 }
 
-impl<'a> ScriptPubkeyExt for ScriptPubkeyRef<'a> {
+impl<'a> AsPtr<btck_ScriptPubkey> for ScriptPubkeyRef<'a> {
     fn as_ptr(&self) -> *const btck_ScriptPubkey {
         self.inner
     }
 }
+
+impl<'a> ScriptPubkeyExt for ScriptPubkeyRef<'a> {}
 
 impl<'a> From<ScriptPubkeyRef<'a>> for Vec<u8> {
     fn from(script_ref: ScriptPubkeyRef<'a>) -> Self {

--- a/src/core/script.rs
+++ b/src/core/script.rs
@@ -5,7 +5,11 @@ use libbitcoinkernel_sys::{
     btck_script_pubkey_destroy, btck_script_pubkey_to_bytes,
 };
 
-use crate::{c_serialize, ffi::sealed::AsPtr, KernelError};
+use crate::{
+    c_serialize,
+    ffi::sealed::{AsPtr, FromPtr},
+    KernelError,
+};
 
 /// Common operations for script pubkeys, implemented by both owned and borrowed types.
 pub trait ScriptPubkeyExt: AsPtr<btck_ScriptPubkey> {
@@ -98,13 +102,6 @@ pub struct ScriptPubkeyRef<'a> {
 }
 
 impl<'a> ScriptPubkeyRef<'a> {
-    pub unsafe fn from_ptr(ptr: *const btck_ScriptPubkey) -> Self {
-        ScriptPubkeyRef {
-            inner: ptr,
-            marker: PhantomData,
-        }
-    }
-
     pub fn to_owned(&self) -> ScriptPubkey {
         ScriptPubkey {
             inner: unsafe { btck_script_pubkey_copy(self.inner) },
@@ -115,6 +112,15 @@ impl<'a> ScriptPubkeyRef<'a> {
 impl<'a> AsPtr<btck_ScriptPubkey> for ScriptPubkeyRef<'a> {
     fn as_ptr(&self) -> *const btck_ScriptPubkey {
         self.inner
+    }
+}
+
+impl<'a> FromPtr<btck_ScriptPubkey> for ScriptPubkeyRef<'a> {
+    unsafe fn from_ptr(ptr: *const btck_ScriptPubkey) -> Self {
+        ScriptPubkeyRef {
+            inner: ptr,
+            marker: PhantomData,
+        }
     }
 }
 

--- a/src/core/transaction.rs
+++ b/src/core/transaction.rs
@@ -31,12 +31,15 @@ pub trait TransactionExt: AsPtr<btck_Transaction> {
     /// # Returns
     /// * `Ok(RefType<TxOut, Transaction>)` - A reference to the output
     /// * `Err(KernelError::OutOfBounds)` - If the index is invalid
-    unsafe fn output(&self, index: usize) -> Result<TxOutRef<'_>, KernelError> {
+    fn output(&self, index: usize) -> Result<TxOutRef<'_>, KernelError> {
         if index >= self.output_count() {
             return Err(KernelError::OutOfBounds);
         }
-        let ptr = unsafe { btck_transaction_get_output_at(self.as_ptr(), index) };
-        Ok(TxOutRef::from_ptr(ptr))
+
+        let tx_out_ref =
+            unsafe { TxOutRef::from_ptr(btck_transaction_get_output_at(self.as_ptr(), index)) };
+
+        Ok(tx_out_ref)
     }
 
     fn input_count(&self) -> usize {

--- a/src/core/transaction.rs
+++ b/src/core/transaction.rs
@@ -8,15 +8,12 @@ use libbitcoinkernel_sys::{
     btck_transaction_output_get_script_pubkey, btck_transaction_to_bytes,
 };
 
-use crate::{c_serialize, KernelError, ScriptPubkeyExt};
+use crate::{c_serialize, ffi::sealed::AsPtr, KernelError, ScriptPubkeyExt};
 
 use super::script::ScriptPubkeyRef;
 
 /// Common operations for transactions, implemented by both owned and borrowed types.
-pub trait TransactionExt {
-    /// Returns a raw pointer to the underlying C object.
-    fn as_ptr(&self) -> *const btck_Transaction;
-
+pub trait TransactionExt: AsPtr<btck_Transaction> {
     /// Returns the number of outputs in this transaction.
     fn output_count(&self) -> usize {
         unsafe { btck_transaction_count_outputs(self.as_ptr()) as usize }
@@ -81,11 +78,13 @@ impl Transaction {
     }
 }
 
-impl TransactionExt for Transaction {
+impl AsPtr<btck_Transaction> for Transaction {
     fn as_ptr(&self) -> *const btck_Transaction {
         self.inner as *const _
     }
 }
+
+impl TransactionExt for Transaction {}
 
 impl Clone for Transaction {
     fn clone(&self) -> Self {
@@ -145,11 +144,13 @@ impl<'a> TransactionRef<'a> {
     }
 }
 
-impl<'a> TransactionExt for TransactionRef<'a> {
+impl<'a> AsPtr<btck_Transaction> for TransactionRef<'a> {
     fn as_ptr(&self) -> *const btck_Transaction {
         self.inner
     }
 }
+
+impl<'a> TransactionExt for TransactionRef<'a> {}
 
 impl<'a> Clone for TransactionRef<'a> {
     fn clone(&self) -> Self {
@@ -160,10 +161,7 @@ impl<'a> Clone for TransactionRef<'a> {
 impl<'a> Copy for TransactionRef<'a> {}
 
 /// Common operations for transaction outputs, implemented by both owned and borrowed types.
-pub trait TxOutExt {
-    /// Returns a raw pointer to the underlying C object.
-    fn as_ptr(&self) -> *const btck_TransactionOutput;
-
+pub trait TxOutExt: AsPtr<btck_TransactionOutput> {
     /// Returns the amount of this output in satoshis.
     fn value(&self) -> i64 {
         unsafe { btck_transaction_output_get_amount(self.as_ptr()) }
@@ -208,11 +206,13 @@ impl TxOut {
     }
 }
 
-impl TxOutExt for TxOut {
+impl AsPtr<btck_TransactionOutput> for TxOut {
     fn as_ptr(&self) -> *const btck_TransactionOutput {
         self.inner as *const _
     }
 }
+
+impl TxOutExt for TxOut {}
 
 impl Clone for TxOut {
     fn clone(&self) -> Self {
@@ -248,11 +248,13 @@ impl<'a> TxOutRef<'a> {
     }
 }
 
-impl<'a> TxOutExt for TxOutRef<'a> {
+impl<'a> AsPtr<btck_TransactionOutput> for TxOutRef<'a> {
     fn as_ptr(&self) -> *const btck_TransactionOutput {
-        self.inner
+        self.inner as *const _
     }
 }
+
+impl<'a> TxOutExt for TxOutRef<'a> {}
 
 impl<'a> Clone for TxOutRef<'a> {
     fn clone(&self) -> Self {

--- a/src/core/transaction.rs
+++ b/src/core/transaction.rs
@@ -8,7 +8,11 @@ use libbitcoinkernel_sys::{
     btck_transaction_output_get_script_pubkey, btck_transaction_to_bytes,
 };
 
-use crate::{c_serialize, ffi::sealed::AsPtr, KernelError, ScriptPubkeyExt};
+use crate::{
+    c_serialize,
+    ffi::sealed::{AsPtr, FromPtr},
+    KernelError, ScriptPubkeyExt,
+};
 
 use super::script::ScriptPubkeyRef;
 
@@ -130,13 +134,6 @@ pub struct TransactionRef<'a> {
 }
 
 impl<'a> TransactionRef<'a> {
-    pub unsafe fn from_ptr(ptr: *const btck_Transaction) -> Self {
-        TransactionRef {
-            inner: ptr,
-            marker: PhantomData,
-        }
-    }
-
     pub fn to_owned(&self) -> Transaction {
         Transaction {
             inner: unsafe { btck_transaction_copy(self.inner) },
@@ -150,6 +147,14 @@ impl<'a> AsPtr<btck_Transaction> for TransactionRef<'a> {
     }
 }
 
+impl<'a> FromPtr<btck_Transaction> for TransactionRef<'a> {
+    unsafe fn from_ptr(ptr: *const btck_Transaction) -> Self {
+        TransactionRef {
+            inner: ptr,
+            marker: PhantomData,
+        }
+    }
+}
 impl<'a> TransactionExt for TransactionRef<'a> {}
 
 impl<'a> Clone for TransactionRef<'a> {
@@ -234,13 +239,6 @@ pub struct TxOutRef<'a> {
 }
 
 impl<'a> TxOutRef<'a> {
-    pub unsafe fn from_ptr(ptr: *const btck_TransactionOutput) -> Self {
-        TxOutRef {
-            inner: ptr,
-            marker: PhantomData,
-        }
-    }
-
     pub fn to_owned(&self) -> TxOut {
         TxOut {
             inner: unsafe { btck_transaction_output_copy(self.inner) },
@@ -251,6 +249,15 @@ impl<'a> TxOutRef<'a> {
 impl<'a> AsPtr<btck_TransactionOutput> for TxOutRef<'a> {
     fn as_ptr(&self) -> *const btck_TransactionOutput {
         self.inner as *const _
+    }
+}
+
+impl<'a> FromPtr<btck_TransactionOutput> for TxOutRef<'a> {
+    unsafe fn from_ptr(ptr: *const btck_TransactionOutput) -> Self {
+        TxOutRef {
+            inner: ptr,
+            marker: PhantomData,
+        }
     }
 }
 

--- a/src/ffi/mod.rs
+++ b/src/ffi/mod.rs
@@ -6,6 +6,16 @@ pub(crate) mod sealed {
         /// Returns a raw pointer to the underlying C object.
         fn as_ptr(&self) -> *const T;
     }
+
+    pub trait FromPtr<T> {
+        /// Creates a wrapper from a raw const C pointer.
+        unsafe fn from_ptr(ptr: *const T) -> Self;
+    }
+
+    pub trait FromMutPtr<T> {
+        /// Creates a wrapper from a raw mutable C pointer.
+        unsafe fn from_ptr(ptr: *mut T) -> Self;
+    }
 }
 
 pub use c_helpers::{enabled, present, success, to_c_bool, to_c_result, to_string};

--- a/src/ffi/mod.rs
+++ b/src/ffi/mod.rs
@@ -1,5 +1,12 @@
 pub mod c_helpers;
 pub mod constants;
 
+pub(crate) mod sealed {
+    pub trait AsPtr<T> {
+        /// Returns a raw pointer to the underlying C object.
+        fn as_ptr(&self) -> *const T;
+    }
+}
+
 pub use c_helpers::{enabled, present, success, to_c_bool, to_c_result, to_string};
 pub(crate) use constants::*;

--- a/src/notifications/validation.rs
+++ b/src/notifications/validation.rs
@@ -5,7 +5,7 @@ use libbitcoinkernel_sys::{
     btck_block_validation_state_get_validation_mode,
 };
 
-use crate::Block;
+use crate::{ffi::sealed::FromMutPtr, Block};
 
 use super::{BlockValidationResult, ValidationMode};
 

--- a/src/state/chain.rs
+++ b/src/state/chain.rs
@@ -6,7 +6,10 @@ use libbitcoinkernel_sys::{
 };
 
 use crate::{
-    ffi::{c_helpers, sealed::AsPtr},
+    ffi::{
+        c_helpers,
+        sealed::{AsPtr, FromPtr},
+    },
     BlockTreeEntry,
 };
 
@@ -44,13 +47,6 @@ pub struct Chain<'a> {
 }
 
 impl<'a> Chain<'a> {
-    pub unsafe fn from_ptr(ptr: *const btck_Chain) -> Self {
-        Chain {
-            inner: ptr,
-            marker: PhantomData,
-        }
-    }
-
     /// Returns the tip (highest block) of the active chain.
     pub fn tip(&self) -> BlockTreeEntry<'a> {
         let ptr = unsafe { btck_chain_get_tip(self.inner) };
@@ -91,6 +87,15 @@ impl<'a> Chain<'a> {
 
     pub fn height(&self) -> i32 {
         unsafe { btck_chain_get_height(self.inner) }
+    }
+}
+
+impl<'a> FromPtr<btck_Chain> for Chain<'a> {
+    unsafe fn from_ptr(ptr: *const btck_Chain) -> Self {
+        Chain {
+            inner: ptr,
+            marker: PhantomData,
+        }
     }
 }
 

--- a/src/state/chain.rs
+++ b/src/state/chain.rs
@@ -5,7 +5,10 @@ use libbitcoinkernel_sys::{
     btck_chain_get_height, btck_chain_get_tip,
 };
 
-use crate::{ffi::c_helpers, BlockTreeEntry};
+use crate::{
+    ffi::{c_helpers, sealed::AsPtr},
+    BlockTreeEntry,
+};
 
 use super::ChainstateManager;
 

--- a/src/state/chainstate.rs
+++ b/src/state/chainstate.rs
@@ -12,7 +12,10 @@ use libbitcoinkernel_sys::{
     btck_chainstate_manager_options_set_worker_threads_num, btck_chainstate_manager_process_block,
 };
 
-use crate::{ffi::c_helpers, Block, BlockHash, BlockSpentOutputs, BlockTreeEntry, KernelError};
+use crate::{
+    ffi::c_helpers, ffi::sealed::AsPtr, Block, BlockHash, BlockSpentOutputs, BlockTreeEntry,
+    KernelError,
+};
 
 use super::{Chain, Context};
 

--- a/src/state/chainstate.rs
+++ b/src/state/chainstate.rs
@@ -13,8 +13,11 @@ use libbitcoinkernel_sys::{
 };
 
 use crate::{
-    ffi::c_helpers, ffi::sealed::AsPtr, Block, BlockHash, BlockSpentOutputs, BlockTreeEntry,
-    KernelError,
+    ffi::{
+        c_helpers,
+        sealed::{AsPtr, FromMutPtr, FromPtr},
+    },
+    Block, BlockHash, BlockSpentOutputs, BlockTreeEntry, KernelError,
 };
 
 use super::{Chain, Context};


### PR DESCRIPTION
## Fix(ffi): introduce sealed traits for internal FFI pointer management

Addresses internal API encapsulation improvements.
Closes https://github.com/TheCharlatan/rust-bitcoinkernel/issues/29

### Internal API Changes
* Replace public `as_ptr` methods with sealed `AsPtr<T>` trait implementations.
* Replace public `from_ptr` methods with sealed `FromPtr<T>` and `FromMutPtr<T>` traits.

### External API Changes
* Removes public `as_ptr` and `from_ptr` methods from all types.
* Removes unsafe marker from output method on TransactionExt.

### Notes:
The sealed trait approach was required for `AsPtr` so that custom traits for each type (e.g., `TransactionExt`, `TxOutExt`) can access `as_ptr` while keeping it crate-private. The `FromPtr` traits were implemented to provide a uniform interface and ensure pointer construction methods also remain crate-private