### PR TITLE
Chore(ci): Add test coverage reporting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,8 +72,20 @@ jobs:
     - name: Check formatting
       run: cargo fmt -- --check
 
-    - name: Run tests
-      run: cargo test -vv
+    - name: Install llvm-tools for coverage
+      run: rustup component add llvm-tools-preview
+
+    - name: Install cargo-llvm-cov
+      run: cargo install cargo-llvm-cov --locked --version 0.6.19
+
+    - name: Run tests with coverage
+      run: cargo llvm-cov --all-features --workspace --html --verbose
+
+    - name: Upload coverage report
+      uses: actions/upload-artifact@v4
+      with:
+        name: coverage-report
+        path: target/llvm-cov/html/
 
     - name: Install Valgrind
       run: |


### PR DESCRIPTION
## Chore(ci): Add test coverage reporting

Integrates `cargo-llvm-cov` to generate test coverage report in CI.

### What this adds:
- HTML coverage reports as downloadable artifacts

### How to view coverage reports:

1. Go to the repository's **Actions** tab
2. Click on the completed workflow run
3. Scroll to the bottom to find the **Artifacts** section
4. Download the `coverage-report` artifact
5. Unzip the file and open `index.html` in your browser

### Why no PR comments?

Automatic PR comments were excluded because GitHub Actions tokens from forked PRs lack `pull-requests: write` permission.
