### PR TITLE
Fix(state): Make set_worker_threads chainable in ChainstateManagerOptions

### DIFF
--- a/fuzz/fuzz_targets/fuzz_target_chainman.rs
+++ b/fuzz/fuzz_targets/fuzz_target_chainman.rs
@@ -88,8 +88,8 @@ fuzz_target!(|data: ChainstateManagerInput| {
     }
     .set_wipe_db(data.wipe_block_index, data.wipe_chainstate_index)
     .set_block_tree_db_in_memory(data.block_tree_db_in_memory)
-    .set_chainstate_db_in_memory(data.chainstate_db_in_memory);
-    chainman_opts.set_worker_threads(data.worker_threads);
+    .set_chainstate_db_in_memory(data.chainstate_db_in_memory)
+    .set_worker_threads(data.worker_threads);
     let chainman = match ChainstateManager::new(chainman_opts) {
         Err(KernelError::Internal(_)) => {
             return;

--- a/src/state/chainstate.rs
+++ b/src/state/chainstate.rs
@@ -166,10 +166,11 @@ impl ChainstateManagerOptions {
     }
 
     /// Set the number of worker threads used by script validation
-    pub fn set_worker_threads(&self, worker_threads: i32) {
+    pub fn set_worker_threads(self, worker_threads: i32) -> Self {
         unsafe {
             btck_chainstate_manager_options_set_worker_threads_num(self.inner, worker_threads);
         }
+        self
     }
 
     /// Wipe the block tree or chainstate dbs. When wiping the block tree db the


### PR DESCRIPTION
### Changes 

makes `set_worker_threads()` chainable in the ChainstateManagerOptions

```rust
// Before: 
opts.set_worker_threads(4);
// After:
opts.set_worker_threads(4).set_chainstate_db_in_memory(true);
```