### PR TITLE
Chore(log): Add warning docs for disable_logging()

### DIFF
--- a/src/log/logging.rs
+++ b/src/log/logging.rs
@@ -54,6 +54,10 @@ impl Drop for Logger {
 }
 
 /// Permanently disable logging and stop buffering.
+///
+/// # Warning
+///
+/// This should only be called once during the lifetime of the program.
 pub fn disable_logging() {
     unsafe {
         btck_logging_disable();


### PR DESCRIPTION
### Changes

Adds warning to the documentation of `disable_logging()` to ensure users do not misuse it.