### PR TITLE
Fix(core): Fix bug in script verification status handling

### DIFF
--- a/src/core/verify.rs
+++ b/src/core/verify.rs
@@ -86,7 +86,6 @@ pub fn verify(
         VERIFY_ALL
     };
 
-    let status = ScriptVerifyStatus::Ok;
     let kernel_amount = amount.unwrap_or_default();
     let kernel_spent_outputs: Vec<*const btck_TransactionOutput> =
         spent_outputs.iter().map(|utxo| utxo.as_ptr()).collect();
@@ -97,6 +96,8 @@ pub fn verify(
         kernel_spent_outputs.as_ptr() as *mut *const btck_TransactionOutput
     };
 
+    let mut status = ScriptVerifyStatus::Ok.into();
+
     let ret = unsafe {
         btck_script_pubkey_verify(
             script_pubkey.as_ptr(),
@@ -106,7 +107,7 @@ pub fn verify(
             spent_outputs.len(),
             input_index as u32,
             kernel_flags,
-            &mut status.into(),
+            &mut status,
         )
     };
 

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -6,7 +6,8 @@ mod tests {
         prelude::*, verify, Block, BlockHash, BlockSpentOutputs, BlockTreeEntry, ChainParams,
         ChainType, ChainstateManager, ChainstateManagerOptions, Coin, Context, ContextBuilder,
         KernelError, Log, Logger, ScriptPubkey, ScriptVerifyError, Transaction,
-        TransactionSpentOutputs, TxOut, TxOutRef, VERIFY_ALL_PRE_TAPROOT,
+        TransactionSpentOutputs, TxOut, TxOutRef, VERIFY_ALL_PRE_TAPROOT, VERIFY_TAPROOT,
+        VERIFY_WITNESS,
     };
     use std::fs::File;
     use std::io::{BufRead, BufReader};
@@ -409,6 +410,38 @@ mod tests {
         assert!(matches!(
             result,
             Err(KernelError::ScriptVerify(ScriptVerifyError::InvalidFlags))
+        ));
+
+        // Test Invalid flags combination
+        let result = verify(
+            &script_pubkey,
+            Some(0),
+            &tx,
+            0,
+            Some(VERIFY_WITNESS),
+            std::slice::from_ref(&dummy_output),
+        );
+        assert!(matches!(
+            result,
+            Err(KernelError::ScriptVerify(
+                ScriptVerifyError::InvalidFlagsCombination
+            ))
+        ));
+
+        // Test Spent outputs required
+        let result = verify(
+            &script_pubkey,
+            Some(0),
+            &tx,
+            0,
+            Some(VERIFY_TAPROOT),
+            &Vec::<TxOut>::new(),
+        );
+        assert!(matches!(
+            result,
+            Err(KernelError::ScriptVerify(
+                ScriptVerifyError::SpentOutputsRequired
+            ))
         ));
     }
 


### PR DESCRIPTION
## Fix(core): Fix bug in script verification status handling

### Problem
The `verify()` function had a bug where script verification errors detected by the C library were not being properly returned. The function would always return `ScriptVerifyError::Invalid` instead of specific errors like `InvalidFlagsCombination`.

### Root Cause
The issue was in how the status parameter was passed to the C function:
```rust
&mut status.into()  // Creates a temporary that's immediately dropped
```

### Solution
Store the converted status in a persistent variable before passing to C:
```rust
let mut status = ScriptVerifyStatus::Ok.into();
// ...
&mut status  // Pass reference to actual variable
```

### Testing
Added test case for `InvalidFlagsCombination` and `SpentOutputsRequired` errors.