### PR TITLE
Chore(examples): Improve silentpaymentscanner example

### DIFF
--- a/examples/src/silentpaymentscanner.rs
+++ b/examples/src/silentpaymentscanner.rs
@@ -5,7 +5,12 @@ use std::sync::Arc;
 
 use bitcoin::consensus::deserialize;
 use bitcoin::hashes::Hash;
+use bitcoin::Transaction;
 use bitcoin::{PrivateKey, XOnlyPublicKey};
+use bitcoinkernel::Block;
+use bitcoinkernel::BlockSpentOutputs;
+use bitcoinkernel::BlockTreeEntry;
+use bitcoinkernel::TransactionSpentOutputsRef;
 use bitcoinkernel::{
     prelude::*, ChainType, ChainstateManager, ChainstateManagerOptions, Context, ContextBuilder,
     KernelError, Log, Logger,
@@ -18,12 +23,235 @@ use silentpayments::utils::receiving::{
     calculate_shared_secret, calculate_tweak_data, get_pubkey_from_input,
 };
 
+#[derive(Debug)]
+enum ScanError {
+    Kernel(KernelError),
+    SilentPayments(String),
+    InvalidInput(String),
+}
+
+impl fmt::Display for ScanError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            ScanError::Kernel(e) => write!(f, "Kernel error: {:?}", e),
+            ScanError::SilentPayments(e) => write!(f, "Silent payments error: {}", e),
+            ScanError::InvalidInput(e) => write!(f, "Invalid input: {}", e),
+        }
+    }
+}
+
+impl std::error::Error for ScanError {}
+
+impl From<KernelError> for ScanError {
+    fn from(e: KernelError) -> Self {
+        ScanError::Kernel(e)
+    }
+}
+
+#[derive(Debug, Clone)]
+struct TransactionInput {
+    prevout_script: Vec<u8>,
+    script_sig: Vec<u8>,
+    witness: Vec<Vec<u8>>,
+    outpoint: (Vec<u8>, u32),
+}
+
+impl fmt::Display for TransactionInput {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "txid: {}, vout: {}",
+            bitcoin::Txid::from_slice(&self.outpoint.0).unwrap(),
+            self.outpoint.1
+        )
+    }
+}
+
+#[derive(Debug, Clone)]
+struct TransactionData {
+    inputs: Vec<TransactionInput>,
+    outputs: Vec<Vec<u8>>,
+}
+
+struct SilentPaymentScanner {
+    receiver: Receiver,
+    secret_scan_key: SecretKey,
+}
+
+impl SilentPaymentScanner {
+    fn new(receiver: Receiver, secret_scan_key: SecretKey) -> Self {
+        Self {
+            receiver,
+            secret_scan_key,
+        }
+    }
+
+    fn scan_chain(&mut self, chainman: &ChainstateManager) -> Result<(), ScanError> {
+        let chain = chainman.active_chain();
+        let tip_height = chain.tip().height();
+
+        log::info!("Starting scan from genesis to tip {}", tip_height);
+
+        for block_index in chain.iter() {
+            if block_index.height() % 10 == 0 {
+                log::info!("Scanning block {} / {}", block_index.height(), tip_height);
+            }
+            self.scan_block(chainman, &block_index)?;
+        }
+
+        Ok(())
+    }
+
+    fn scan_block(
+        &mut self,
+        chainman: &ChainstateManager,
+        block_index: &BlockTreeEntry,
+    ) -> Result<(), ScanError> {
+        let spent_outputs: BlockSpentOutputs = chainman.read_spent_outputs(block_index)?;
+        let block: Block = chainman.read_block_data(block_index)?;
+
+        for (index, tx_spent_output) in spent_outputs.iter().enumerate() {
+            let tx_index = index + 1;
+            let tx_bytes = block.transaction(tx_index).unwrap().consensus_encode()?;
+            let tx: Transaction = deserialize(&tx_bytes).map_err(|e| {
+                ScanError::InvalidInput(format!("Failed to deserialize transaction {}", e))
+            })?;
+            let tx_data = self.extract_transaction_data(tx, tx_spent_output)?;
+            self.scan_transaction(&tx_data)?;
+        }
+
+        Ok(())
+    }
+
+    fn extract_transaction_data(
+        &mut self,
+        tx: bitcoin::Transaction,
+        tx_spent_outputs: TransactionSpentOutputsRef,
+    ) -> Result<TransactionData, ScanError> {
+        if tx.input.len() != tx_spent_outputs.count() {
+            return Err(ScanError::InvalidInput(format!(
+                "Transaction input count mismatch: {} inputs vs {} spent outputs",
+                tx.input.len(),
+                tx_spent_outputs.count()
+            )));
+        }
+
+        let mut inputs = Vec::new();
+        for (index, coin) in tx_spent_outputs.coins().enumerate() {
+            inputs.push(TransactionInput {
+                prevout_script: coin.output().script_pubkey().to_bytes(),
+                script_sig: tx.input[index].script_sig.to_bytes(),
+                witness: tx.input[index].witness.to_vec(),
+                outpoint: (
+                    tx.input[index]
+                        .previous_output
+                        .txid
+                        .to_byte_array()
+                        .to_vec(),
+                    tx.input[index].previous_output.vout,
+                ),
+            });
+        }
+
+        let outputs = tx
+            .output
+            .iter()
+            .map(|output| output.script_pubkey.to_bytes())
+            .collect();
+
+        Ok(TransactionData { inputs, outputs })
+    }
+
+    fn scan_transaction(&mut self, tx_data: &TransactionData) -> Result<(), ScanError> {
+        let input_pub_keys: Result<Vec<_>, _> = tx_data
+            .inputs
+            .iter()
+            .map(|input| {
+                get_pubkey_from_input(&input.script_sig, &input.witness, &input.prevout_script)
+                    .map_err(|e| {
+                        ScanError::SilentPayments(format!("Failed to extract pubkey: {:?}", e))
+                    })
+            })
+            .collect();
+
+        let input_pub_keys: Vec<PublicKey> = match input_pub_keys {
+            Ok(keys) => keys.into_iter().flatten().collect(),
+            Err(e) => {
+                log::debug!("Failed to extract pubkeys: {}", e);
+                return Ok(());
+            }
+        };
+
+        if input_pub_keys.is_empty() {
+            return Ok(());
+        }
+
+        let pubkeys_ref: Vec<&PublicKey> = input_pub_keys.iter().collect();
+
+        let outpoints_data: Vec<_> = tx_data
+            .inputs
+            .iter()
+            .map(|input| {
+                let txid = bitcoin::Txid::from_slice(&input.outpoint.0)
+                    .unwrap()
+                    .to_string();
+                (txid, input.outpoint.1)
+            })
+            .collect();
+
+        let tweak_data = calculate_tweak_data(&pubkeys_ref, &outpoints_data).map_err(|e| {
+            ScanError::SilentPayments(format!("Failed to calculcate tweak: {:?}", e))
+        })?;
+
+        let ecdh_shared_secret = calculate_shared_secret(tweak_data, self.secret_scan_key)
+            .map_err(|e| {
+                ScanError::SilentPayments(format!("Failed to calculate shared secret: {:?}", e))
+            })?;
+
+        let pubkeys_to_check: Vec<XOnlyPublicKey> = tx_data
+            .outputs
+            .iter()
+            .filter_map(|script_pubkey| {
+                if script_pubkey.len() == 34 && script_pubkey[0] == 0x51 && script_pubkey[1] == 0x20
+                {
+                    XOnlyPublicKey::from_slice(&script_pubkey[2..]).ok()
+                } else {
+                    None
+                }
+            })
+            .collect();
+
+        if pubkeys_to_check.is_empty() {
+            log::info!("pub keys to check is empty!");
+            return Ok(());
+        }
+
+        match self
+            .receiver
+            .scan_transaction(&ecdh_shared_secret, pubkeys_to_check)
+        {
+            Ok(outputs) if !outputs.is_empty() => {
+                log::info!("Found {} silent payments output(s)!", outputs.len());
+                for (idx, output) in outputs.iter().enumerate() {
+                    log::info!("Output {}: {:?}", idx + 1, output);
+                }
+            }
+            Ok(_) => {}
+            Err(e) => {
+                log::debug!("Scan failed: {:?}", e);
+            }
+        }
+
+        Ok(())
+    }
+}
+
 struct MainLog {}
 
 impl Log for MainLog {
     fn log(&self, message: &str) {
         log::info!(
-            target: "libbitcoinkernel", 
+            target: "libbitcoinkernel",
             "{}", message.strip_suffix("\r\n").or_else(|| message.strip_suffix('\n')).unwrap_or(message));
     }
 }
@@ -43,56 +271,6 @@ fn create_context() -> Arc<Context> {
     )
 }
 
-fn vec_to_hex_string(data: &Vec<u8>) -> String {
-    let mut hex_string = String::with_capacity(data.len() * 2);
-    for byte in data {
-        hex_string.push_str(&format!("{:02x}", byte));
-    }
-    hex_string
-}
-
-#[derive(Debug, Clone)]
-struct Input {
-    prevout: Vec<u8>,
-    script_sig: Vec<u8>,
-    witness: Vec<Vec<u8>>,
-    prevout_data: (Vec<u8>, u32),
-}
-
-#[derive(Debug, Clone)]
-struct ScanTxHelper {
-    ins: Vec<Input>,
-    outs: Vec<Vec<u8>>,
-}
-
-impl fmt::Display for Input {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "prevout: {}, ", vec_to_hex_string(&self.prevout))?;
-        write!(f, "script_sig: {}, ", vec_to_hex_string(&self.script_sig))?;
-        for witness_elem in self.witness.iter() {
-            write!(f, "witness: {}, ", vec_to_hex_string(&witness_elem))?;
-        }
-        write!(
-            f,
-            "prevout txid: {}, ",
-            bitcoin::Txid::from_slice(&self.prevout_data.0).unwrap()
-        )?;
-        write!(f, "prevout n: {}, ", self.prevout_data.1)
-    }
-}
-
-impl fmt::Display for ScanTxHelper {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        for input in self.ins.iter() {
-            write!(f, "input: {}\n", input)?;
-        }
-        for output in self.outs.iter() {
-            write!(f, "output: {}\n", vec_to_hex_string(&output))?;
-        }
-        write!(f, "")
-    }
-}
-
 // silent payment txid:
 // 4282b1727f0ebb0c035e8306c2c09764b5b637d63ae5249f7d0d1968a1554231
 // silent payment tx:
@@ -104,137 +282,61 @@ impl fmt::Display for ScanTxHelper {
 // scan key:
 // cTiSJ8p2zpGSkWGkvYFWfKurgWvSi9hdvzw9GEws18kS2VRPNS24
 
-fn parse_keys() -> (Receiver, SecretKey) {
+fn parse_keys() -> Result<(Receiver, SecretKey), ScanError> {
     let original = "sprt1qqw7zfpjcuwvq4zd3d4aealxq3d669s3kcde4wgr3zl5ugxs40twv2qccgvszutt7p796yg4h926kdnty66wxrfew26gu2gk5h5hcg4s2jqyascfz";
 
-    let spend_key =
-        PrivateKey::from_wif("cRFcZbp7cAeZGsnYKdgSZwH6drJ3XLnPSGcjLNCpRy28tpGtZR11").unwrap();
-    let scan_key =
-        PrivateKey::from_wif("cTiSJ8p2zpGSkWGkvYFWfKurgWvSi9hdvzw9GEws18kS2VRPNS24").unwrap();
+    let spend_key: PrivateKey =
+        PrivateKey::from_wif("cRFcZbp7cAeZGsnYKdgSZwH6drJ3XLnPSGcjLNCpRy28tpGtZR11")
+            .map_err(|e| ScanError::InvalidInput(format!("Invalid spend key: {}", e)))?;
+
+    let scan_key: PrivateKey =
+        PrivateKey::from_wif("cTiSJ8p2zpGSkWGkvYFWfKurgWvSi9hdvzw9GEws18kS2VRPNS24")
+            .map_err(|e| ScanError::InvalidInput(format!("Invalid scan key: {}", e)))?;
 
     let secp = Secp256k1::new();
     let public_spend_key: secp256k1::PublicKey = spend_key.public_key(&secp).inner;
     let public_scan_key: secp256k1::PublicKey = scan_key.public_key(&secp).inner;
 
     let label = Label::new(spend_key.inner, 0);
-    let receiver = Receiver::new(0, public_scan_key, public_spend_key, label, false).unwrap();
+    let receiver = Receiver::new(0, public_scan_key, public_spend_key, label, false)
+        .map_err(|e| ScanError::SilentPayments(format!("Failed to create receiver: {:?}", e)))?;
     println!("Receiver address: {}", receiver.get_receiving_address());
     println!("Actual adress:    {}", original);
-    (receiver, scan_key.inner)
+
+    Ok((receiver, scan_key.inner))
 }
 
-fn scan_tx(receiver: &Receiver, secret_scan_key: &SecretKey, scan_tx_helper: ScanTxHelper) {
-    let input_pub_keys: Vec<PublicKey> = scan_tx_helper
-        .ins
-        .iter()
-        .filter_map(|input| {
-            get_pubkey_from_input(&input.script_sig, &input.witness, &input.prevout).unwrap()
-        })
-        .collect();
-    let pubkeys_ref: Vec<&PublicKey> = input_pub_keys.iter().collect();
-    let outpoints_data: Vec<_> = scan_tx_helper
-        .ins
-        .iter()
-        .map(|input| {
-            let txid = bitcoin::Txid::from_slice(&input.prevout_data.0)
-                .unwrap()
-                .to_string();
-            (txid, input.prevout_data.1)
-        })
-        .collect();
-    let tweak_data = calculate_tweak_data(&pubkeys_ref, &outpoints_data).unwrap();
-    let ecdh_shared_secret = calculate_shared_secret(tweak_data, *secret_scan_key).unwrap();
-    let pubkeys_to_check: Vec<XOnlyPublicKey> = scan_tx_helper
-        .outs
-        .iter()
-        .filter_map(|script_pubkey| {
-            if let Ok(res) = XOnlyPublicKey::from_slice(&script_pubkey[2..]) {
-                Some(res)
-            } else {
-                None
-            }
-        })
-        .collect();
-    if let Ok(res) = receiver.scan_transaction(&ecdh_shared_secret, pubkeys_to_check) {
-        println!("\nres: {:?}\n", res);
-    }
-}
-
-fn scan_txs(chainman: &ChainstateManager) {
-    let (receiver, secret_scan_key) = parse_keys();
-    let chain = chainman.active_chain();
-    let mut block_index = chain.tip();
-
-    loop {
-        if block_index.height() <= 1 {
-            break;
-        }
-        let spent_outputs = chainman.read_spent_outputs(&block_index).unwrap();
-        let raw_block: Vec<u8> = chainman
-            .read_block_data(&block_index)
-            .unwrap()
-            .try_into()
-            .unwrap();
-        let block: bitcoin::Block = deserialize(&raw_block).unwrap();
-        // Should be the same size minus the coinbase transaction
-        assert_eq!(block.txdata.len() - 1, spent_outputs.count());
-
-        for i in 0..(block.txdata.len() - 1) {
-            let tx_spent_outputs = spent_outputs.transaction_spent_outputs(i).unwrap();
-            let coins_spent_count = tx_spent_outputs.count();
-            let transaction_input_size = block.txdata[i + 1].input.len();
-            assert_eq!(transaction_input_size, coins_spent_count);
-            let mut scan_tx_helper = ScanTxHelper {
-                ins: vec![],
-                outs: block.txdata[i + 1]
-                    .output
-                    .iter()
-                    .map(|output| output.script_pubkey.to_bytes())
-                    .collect(),
-            };
-            for j in 0..transaction_input_size {
-                let coin = tx_spent_outputs.coin(j).unwrap();
-                scan_tx_helper.ins.push(Input {
-                    prevout: coin.output().script_pubkey().to_bytes(),
-                    script_sig: block.txdata[i + 1].input[j].script_sig.to_bytes(),
-                    witness: block.txdata[i + 1].input[j].witness.to_vec(),
-                    prevout_data: (
-                        block.txdata[i + 1].input[j]
-                            .previous_output
-                            .txid
-                            .to_byte_array()
-                            .to_vec(),
-                        block.txdata[i + 1].input[j].previous_output.vout,
-                    ),
-                });
-            }
-            scan_tx(&receiver, &secret_scan_key, scan_tx_helper.clone());
-            println!("helper: {:?}", scan_tx_helper);
-        }
-        block_index = match block_index.prev() {
-            Some(block_index_prev) => block_index_prev,
-            None => break,
-        };
-    }
-    log::info!("scanned txs!");
-}
-
-fn main() {
+fn run() -> Result<(), Box<dyn std::error::Error>> {
     let args: Vec<String> = env::args().collect();
 
-    if args.len() < 2 {
+    if args.len() < 1 {
         eprintln!("Usage: {} <path_to_data_dir>", args[0]);
         process::exit(1);
     }
 
-    let _ = setup_logging().unwrap();
+    let _logger = setup_logging().unwrap();
     let context = create_context();
     let data_dir = args[1].clone();
-    let blocks_dir = data_dir.clone() + "/blocks";
+    let blocks_dir = format!("{}/blocks", data_dir);
+
     let chainman = ChainstateManager::new(
         ChainstateManagerOptions::new(&context, &data_dir, &blocks_dir).unwrap(),
     )
     .unwrap();
+
     chainman.import_blocks().unwrap();
-    scan_txs(&chainman);
+
+    let (receiver, secret_scan_key) = parse_keys()?;
+    let mut scanner = SilentPaymentScanner::new(receiver, secret_scan_key);
+
+    let _ = scanner.scan_chain(&chainman);
+
+    Ok(())
+}
+
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("Error: {}", e);
+        process::exit(1);
+    }
 }


### PR DESCRIPTION
### Changes

Closes https://github.com/TheCharlatan/rust-bitcoinkernel/issues/26

Restructures the silent payment scanner examples and applies iterators.

The aim is to better demonstrate the features of the library