### PR TITLE
Fix(core): add BlockHashExt to public exports

### DIFF
--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -12,7 +12,7 @@ pub use block_tree_entry::BlockTreeEntry;
 pub use script::{ScriptPubkey, ScriptPubkeyRef};
 pub use transaction::{Transaction, TransactionRef, TxOut, TxOutRef};
 
-pub use block::{BlockSpentOutputsExt, CoinExt, TransactionSpentOutputsExt};
+pub use block::{BlockHashExt, BlockSpentOutputsExt, CoinExt, TransactionSpentOutputsExt};
 pub use script::ScriptPubkeyExt;
 pub use transaction::{TransactionExt, TxOutExt};
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -121,7 +121,7 @@ pub use crate::core::verify_flags::{
 
 pub mod prelude {
     pub use crate::core::{
-        BlockSpentOutputsExt, CoinExt, ScriptPubkeyExt, TransactionExt, TransactionSpentOutputsExt,
-        TxOutExt,
+        BlockHashExt, BlockSpentOutputsExt, CoinExt, ScriptPubkeyExt, TransactionExt,
+        TransactionSpentOutputsExt, TxOutExt,
     };
 }


### PR DESCRIPTION
### Changes:

Exports BlockHashExt trait in core module and includes it in the prelude for easier access to block hash extension methods.