### PR TITLE
Feat(fuzz): verify serialization stability in block_roundtrip

### DIFF
--- a/fuzz/fuzz_targets/block_roundtrip.rs
+++ b/fuzz/fuzz_targets/block_roundtrip.rs
@@ -4,8 +4,17 @@ use bitcoinkernel::Block;
 use libfuzzer_sys::fuzz_target;
 
 fuzz_target!(|data: &[u8]| {
-    if let Ok(block) = Block::try_from(data) {
-        let block_serialized: Vec<u8> = block.try_into().unwrap();
-        assert!(data.len() >= block_serialized.len());
-    }
+    let Ok(block) = Block::try_from(data) else {
+        return;
+    };
+
+    let serialized: Vec<u8> = block.try_into().unwrap();
+    let roundtrip =
+        Block::try_from(serialized.as_slice()).expect("Serialized block should deserialize");
+    let reserialized: Vec<u8> = roundtrip.try_into().unwrap();
+
+    assert_eq!(
+        serialized, reserialized,
+        "Serialization must be stable across roundtrips"
+    );
 });


### PR DESCRIPTION
## Feat(fuzz): verify serialization stability in block_roundtrip

### Changes

Improve the block_roundtrip fuzz target to test that serialization is deterministic by verifying that deserialize -> serialize -> deserialize -> serialize produces identical output.