### PR TITLE
Feat(ci): Add fuzz corpus verification workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -183,57 +183,6 @@ jobs:
     - name: Build and test
       run: cargo test -vv
 
-  fuzzing:
-    name: Check Fuzzing Setup
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/checkout@v3
-
-    - name: Install Rust toolchain
-      uses: actions-rs/toolchain@v1
-      with:
-        profile: minimal
-        toolchain: nightly
-        override: true
-        targets: x86_64-unknown-linux-gnu
-
-    - name: Install LLVM tools for sanitizers
-      run: |
-        sudo apt-get update
-        sudo apt-get install -y llvm
-
-    - name: Cache dependencies
-      uses: Swatinem/rust-cache@v2
- 
-    - name: Install Boost library
-      run: |
-        sudo apt-get update
-        sudo apt-get install -y libboost-all-dev
- 
-    - name: Install cargo-fuzz
-      run: cargo install cargo-fuzz
-
-    - name: Set up fuzzing directories
-      run: |
-        mkdir -p /tmp/rust_kernel_fuzz
-        sudo mount -t tmpfs none /tmp/rust_kernel_fuzz || true
- 
-    - name: Build and run fuzzing with Address Sanitizer
-      env:
-        RUSTFLAGS: "-Zsanitizer=address"
-        ASAN_OPTIONS: "detect_leaks=1"
-      run: |
-        # First compile the main crate with sanitizer flags
-        cargo build --verbose
-        # Now build and run the fuzzing targets with the same sanitizer flags
-        cargo fuzz build block_roundtrip
-        cargo fuzz build chainman_process_block
-        cargo fuzz build script_verify
-        cargo fuzz run block_roundtrip -- -max_total_time=20
-        cargo fuzz run chainman_process_block -- -max_total_time=20
-        cargo fuzz run script_verify -- -max_total_time=20
-
   fuzz-corpus:
     name: Verify Fuzz Corpus
     runs-on: ubuntu-latest


### PR DESCRIPTION
### Feat(ci): Add fuzz corpus verification workflow

Related to https://github.com/TheCharlatan/rust-bitcoinkernel/issues/35

### Changes

Add a new CI job that verifies fuzz corpus files from the [qa-assets repository](https://github.com/alexanderwiederin/qa-assets) against all fuzz targets. The job:

- Checks that corpus directories exist and contain files
- Verifies all corpus files exectue without crashes with -runs=0 (no new input generation)
- Uploads crash artifacts on failure for debugging

This ensures corpus files remain valid as the codebase evovles and helps catch regressions that might cause previously-valid inputs to crash.

*note: more fuzz tests will be added in later PRs in similar fashion.*