### PR TITLE
Feat(fuzz): Add transaction_roundtrip fuzz test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -194,6 +194,7 @@ jobs:
           - block_roundtrip
           - chainman_process_block
           - script_verify
+          - transaction_roundtrip
 
     steps:
       - name: Checkout rust-bitcoinkernel

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -34,3 +34,10 @@ path = "fuzz_targets/block_roundtrip.rs"
 test = false
 doc = false
 bench = false
+
+[[bin]]
+name = "transaction_roundtrip"
+path = "fuzz_targets/transaction_roundtrip.rs"
+test = false
+doc = false
+bench = false

--- a/fuzz/fuzz_targets/transaction_roundtrip.rs
+++ b/fuzz/fuzz_targets/transaction_roundtrip.rs
@@ -1,0 +1,21 @@
+#![no_main]
+use bitcoinkernel::Transaction;
+use libfuzzer_sys::fuzz_target;
+
+fuzz_target!(|data: &[u8]| {
+    let Ok(transaction) = Transaction::try_from(data) else {
+        return;
+    };
+
+    let serialized: Vec<u8> = transaction.try_into().unwrap();
+
+    let roundtrip = Transaction::try_from(serialized.as_slice())
+        .expect("Serialized transaction should deserialize");
+
+    let reserialized: Vec<u8> = roundtrip.try_into().unwrap();
+
+    assert_eq!(
+        serialized, reserialized,
+        "Serialization must be stable across roundtrips"
+    );
+});


### PR DESCRIPTION
Related to https://github.com/TheCharlatan/rust-bitcoinkernel/issues/35

### Changes

Added the transaction_roundtrip fuzz test. The corpus is minimized and derived from core's `qa-assets/fuzz-copora/transaction` corpus.
