### PR TITLE
Fix(fuzz): Prevent macOS crash in chainman_process_block

### DIFF
--- a/fuzz/fuzz_targets/chainman_process_block.rs
+++ b/fuzz/fuzz_targets/chainman_process_block.rs
@@ -75,7 +75,7 @@ fuzz_target!(|data: ChainstateManagerInput| {
     let sanitized_string: String = data
         .data_dir
         .chars()
-        .filter(|c| *c != '.' && *c != '/')
+        .filter(|c| c.is_ascii_alphanumeric() || *c == '_' || *c == '-')
         .take(60)
         .collect();
 


### PR DESCRIPTION
### Changes
Restrict path sanitzation to ASCII alphanumeric plus [_-] to prevent filesystem-specific failures.

Fixes crash with input: 8rGxsVYbEPf/EACA