### PR TITLE
Chore(lib): Fix typo in InvalidLength error field name

### DIFF
--- a/src/core/block.rs
+++ b/src/core/block.rs
@@ -46,7 +46,7 @@ impl BlockHash {
     pub fn new(raw_bytes: &[u8]) -> Result<Self, KernelError> {
         if raw_bytes.len() != 32 {
             return Err(KernelError::InvalidLength {
-                expcted: 32,
+                expected: 32,
                 actual: raw_bytes.len(),
             });
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,7 +74,7 @@ pub enum KernelError {
     OutOfBounds,
     ScriptVerify(ScriptVerifyError),
     SerializationFailed,
-    InvalidLength { expcted: usize, actual: usize },
+    InvalidLength { expected: usize, actual: usize },
 }
 
 impl From<NulError> for KernelError {


### PR DESCRIPTION
### Changes

Change 'expcted' to 'expected' in the InvalidLength variant of KernelError enum and its usage in BlockHash::new().