### PR TITLE
Feat(state): Add error handling for invalid wipe_db configuration

### DIFF
--- a/tests/test.rs
+++ b/tests/test.rs
@@ -149,7 +149,8 @@ mod tests {
 
         let chainman_builder = ChainstateManager::builder(&context, &data_dir, &blocks_dir)
             .unwrap()
-            .wipe_db(false, true);
+            .wipe_db(false, true)
+            .unwrap();
 
         let chainman = chainman_builder.build().unwrap();
         chainman.import_blocks().unwrap();


### PR DESCRIPTION
### Changes

The wipe_db method now returns a Result and validates that wiping the block tree database without also wiping the chainstate is not allowed, as this combination is currently unsupported by the C API.