### PR TITLE
Feat(notifications): Expose BlockValidationState types in public API

### DIFF
--- a/fuzz/fuzz_targets/chainman_process_block.rs
+++ b/fuzz/fuzz_targets/chainman_process_block.rs
@@ -7,10 +7,8 @@ use libfuzzer_sys::fuzz_target;
 use arbitrary::Arbitrary;
 
 use bitcoinkernel::{
-    disable_logging,
-    notifications::types::{BlockValidationStateExt, BlockValidationStateRef},
-    Block, ChainType, ChainstateManagerBuilder, Context, ContextBuilder, KernelError,
-    ValidationMode,
+    disable_logging, prelude::*, Block, BlockValidationStateRef, ChainType,
+    ChainstateManagerBuilder, Context, ContextBuilder, KernelError, ValidationMode,
 };
 
 fn create_context(chain_type: ChainType) -> Arc<Context> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -119,10 +119,10 @@ pub use crate::core::{
 pub use crate::log::{disable_logging, Log, LogCategory, LogLevel, Logger};
 
 pub use crate::notifications::{
-    BlockCheckedCallback, BlockTipCallback, BlockValidationResult, FatalErrorCallback,
-    FlushErrorCallback, HeaderTipCallback, NotificationCallbackRegistry, ProgressCallback,
-    SynchronizationState, ValidationCallbackRegistry, ValidationMode, Warning, WarningSetCallback,
-    WarningUnsetCallback,
+    BlockCheckedCallback, BlockTipCallback, BlockValidationResult, BlockValidationStateRef,
+    FatalErrorCallback, FlushErrorCallback, HeaderTipCallback, NotificationCallbackRegistry,
+    ProgressCallback, SynchronizationState, ValidationCallbackRegistry, ValidationMode, Warning,
+    WarningSetCallback, WarningUnsetCallback,
 };
 
 pub use crate::state::{
@@ -140,4 +140,5 @@ pub mod prelude {
         BlockHashExt, BlockSpentOutputsExt, CoinExt, ScriptPubkeyExt, TransactionExt,
         TransactionSpentOutputsExt, TxOutExt,
     };
+    pub use crate::notifications::BlockValidationStateExt;
 }

--- a/src/notifications/mod.rs
+++ b/src/notifications/mod.rs
@@ -2,7 +2,10 @@ pub mod notification;
 pub mod types;
 pub mod validation;
 
-pub use types::{BlockValidationResult, SynchronizationState, ValidationMode, Warning};
+pub use types::{
+    BlockValidationResult, BlockValidationStateExt, BlockValidationStateRef, SynchronizationState,
+    ValidationMode, Warning,
+};
 
 pub use notification::{
     BlockTipCallback, FatalErrorCallback, FlushErrorCallback, HeaderTipCallback,

--- a/src/notifications/types.rs
+++ b/src/notifications/types.rs
@@ -228,9 +228,7 @@ impl<'a> BlockValidationStateExt for BlockValidationStateRef<'a> {}
 mod tests {
     use libbitcoinkernel_sys::btck_BlockValidationState;
 
-    use crate::{
-        ffi::test_utils::test_ref_trait_requirements, notifications::types::BlockValidationStateRef,
-    };
+    use crate::ffi::test_utils::test_ref_trait_requirements;
 
     use super::*;
 

--- a/src/notifications/validation.rs
+++ b/src/notifications/validation.rs
@@ -4,8 +4,7 @@ use libbitcoinkernel_sys::{btck_Block, btck_BlockTreeEntry, btck_BlockValidation
 
 use crate::{
     ffi::sealed::{FromMutPtr, FromPtr},
-    notifications::types::BlockValidationStateRef,
-    Block, BlockTreeEntry,
+    Block, BlockTreeEntry, BlockValidationStateRef,
 };
 
 /// Exposes the result after validating a block.
@@ -184,7 +183,7 @@ pub(crate) unsafe extern "C" fn validation_block_disconnected_wrapper(
 mod tests {
     use std::sync::{Arc, Mutex};
 
-    use crate::{notifications::types::BlockValidationStateExt, BlockValidationResult};
+    use crate::{prelude::*, BlockValidationResult};
 
     use super::*;
 

--- a/src/state/context.rs
+++ b/src/state/context.rs
@@ -368,7 +368,7 @@ impl From<btck_ChainType> for ChainType {
 
 #[cfg(test)]
 mod tests {
-    use crate::{notifications::types::BlockValidationStateRef, BlockTreeEntry};
+    use crate::{BlockTreeEntry, BlockValidationStateRef};
 
     use super::*;
 


### PR DESCRIPTION
### Feat(notifications): Expose BlockValidationState types in public API

Export BlockValidationStateRef at the crate root and add BlockValidationStateExt to the prelude module. These types allow users to interact with block validation state in validation callbacks.

Update internal imports throughout the codebase to use the new public path.