### PR TITLE
refactor(core): move BlockHash::as_ref implementation to main impl block

### DIFF
--- a/src/core/block.rs
+++ b/src/core/block.rs
@@ -60,6 +60,10 @@ impl BlockHash {
             Ok(BlockHash { inner })
         }
     }
+
+    pub fn as_ref(&self) -> BlockHashRef<'_> {
+        unsafe { BlockHashRef::from_ptr(self.inner as *const _) }
+    }
 }
 
 impl AsPtr<btck_BlockHash> for BlockHash {
@@ -269,12 +273,6 @@ impl Block {
     /// Returns an iterator over all transactions in this block.
     pub fn transactions(&self) -> BlockTransactionIter<'_> {
         BlockTransactionIter::new(self)
-    }
-}
-
-impl BlockHash {
-    pub fn as_ref(&self) -> BlockHashRef<'_> {
-        unsafe { BlockHashRef::from_ptr(self.inner as *const _) }
     }
 }
 


### PR DESCRIPTION
### Changes

The `as_ref` method for BlockHash was relocated from a separate impl block to the primary implementation.