### PR TITLE
Feat(core): Add `TxOutPoint` types, `Txid` types and `TxInRef` to public API

### DIFF
--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -12,11 +12,12 @@ pub use block_tree_entry::BlockTreeEntry;
 pub use script::{ScriptPubkey, ScriptPubkeyRef};
 pub use transaction::{
     Transaction, TransactionRef, TxIn, TxInRef, TxOut, TxOutPoint, TxOutPointRef, TxOutRef, Txid,
+    TxidRef,
 };
 
 pub use block::{BlockHashExt, BlockSpentOutputsExt, CoinExt, TransactionSpentOutputsExt};
 pub use script::ScriptPubkeyExt;
-pub use transaction::{TransactionExt, TxInExt, TxOutExt, TxOutPointExt};
+pub use transaction::{TransactionExt, TxInExt, TxOutExt, TxOutPointExt, TxidExt};
 
 pub use verify::{verify, ScriptVerifyError, ScriptVerifyStatus};
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -114,7 +114,7 @@ pub use crate::core::{
     verify, Block, BlockHash, BlockSpentOutputs, BlockSpentOutputsRef, BlockTreeEntry, Coin,
     CoinRef, ScriptPubkey, ScriptPubkeyRef, ScriptVerifyError, ScriptVerifyStatus, Transaction,
     TransactionRef, TransactionSpentOutputs, TransactionSpentOutputsRef, TxIn, TxInRef, TxOut,
-    TxOutPoint, TxOutPointRef, TxOutRef,
+    TxOutPoint, TxOutPointRef, TxOutRef, Txid, TxidRef,
 };
 
 pub use crate::log::{disable_logging, Log, LogCategory, LogLevel, Logger};
@@ -139,7 +139,7 @@ pub use crate::core::verify_flags::{
 pub mod prelude {
     pub use crate::core::{
         BlockHashExt, BlockSpentOutputsExt, CoinExt, ScriptPubkeyExt, TransactionExt,
-        TransactionSpentOutputsExt, TxInExt, TxOutExt, TxOutPointExt,
+        TransactionSpentOutputsExt, TxInExt, TxOutExt, TxOutPointExt, TxidExt,
     };
     pub use crate::notifications::BlockValidationStateExt;
 }


### PR DESCRIPTION
### Changes

- Adds `TxOutPointExt` and `TxidExt` to public prelude module.
- Adds exports for `TxOutPoint`, `TxOutPointRef`, `Txid`, `TxidRef` and `TxInRef` at the crate root