### PR TITLE
Refactor(core): Make ScriptVerifyStatus private

### DIFF
--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -19,7 +19,7 @@ pub use block::{BlockHashExt, BlockSpentOutputsExt, CoinExt, TransactionSpentOut
 pub use script::ScriptPubkeyExt;
 pub use transaction::{TransactionExt, TxInExt, TxOutExt, TxOutPointExt, TxidExt};
 
-pub use verify::{verify, ScriptVerifyError, ScriptVerifyStatus};
+pub use verify::{verify, ScriptVerifyError};
 
 pub mod verify_flags {
     pub use super::verify::{

--- a/src/core/verify.rs
+++ b/src/core/verify.rs
@@ -139,7 +139,7 @@ pub fn verify(
 /// configuration errors that prevented verification from proceeding.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 #[repr(u8)]
-pub enum ScriptVerifyStatus {
+enum ScriptVerifyStatus {
     /// Script verification completed successfully
     Ok = BTCK_SCRIPT_VERIFY_STATUS_OK,
     /// Invalid combination of verification flags was provided

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -112,9 +112,9 @@ impl std::error::Error for KernelError {
 
 pub use crate::core::{
     verify, Block, BlockHash, BlockSpentOutputs, BlockSpentOutputsRef, BlockTreeEntry, Coin,
-    CoinRef, ScriptPubkey, ScriptPubkeyRef, ScriptVerifyError, ScriptVerifyStatus, Transaction,
-    TransactionRef, TransactionSpentOutputs, TransactionSpentOutputsRef, TxIn, TxInRef, TxOut,
-    TxOutPoint, TxOutPointRef, TxOutRef, Txid, TxidRef,
+    CoinRef, ScriptPubkey, ScriptPubkeyRef, ScriptVerifyError, Transaction, TransactionRef,
+    TransactionSpentOutputs, TransactionSpentOutputsRef, TxIn, TxInRef, TxOut, TxOutPoint,
+    TxOutPointRef, TxOutRef, Txid, TxidRef,
 };
 
 pub use crate::log::{disable_logging, Log, LogCategory, LogLevel, Logger};


### PR DESCRIPTION
## Refactor(core): Make ScriptVerifyStatus private

### Reasoning

ScriptVerifyStatus is an internal implementation detail used only to communicate status codes from the C verification function. Users interact with the public verify() function which returns Result<(), KernelError>, so this enum doesn't need to be exposed in the public API.