### PR TITLE
test: Precise the script tests a bit more

### DIFF
--- a/tests/test.rs
+++ b/tests/test.rs
@@ -5,9 +5,10 @@ mod tests {
         BlockValidationStateRef, ChainParams, ChainType, ChainstateManager,
         ChainstateManagerBuilder, Coin, Context, ContextBuilder, KernelError, Log, Logger,
         PrecomputedTransactionData, ScriptPubkey, ScriptVerifyError, Transaction,
-        TransactionSpentOutputs, TxIn, TxOut, TxOutRef, VERIFY_ALL, VERIFY_ALL_PRE_TAPROOT,
-        VERIFY_TAPROOT, VERIFY_WITNESS,
+        TransactionSpentOutputs, TxIn, TxOut, VERIFY_ALL, VERIFY_ALL_PRE_TAPROOT, VERIFY_TAPROOT,
+        VERIFY_WITNESS,
     };
+    use libbitcoinkernel_sys::btck_ScriptVerificationFlags;
     use std::fs::File;
     use std::io::{BufRead, BufReader};
     use std::sync::{Arc, Once};
@@ -245,59 +246,50 @@ mod tests {
         verify_test (
             "76a9144bfbaf6afb76cc5771bc6404810d1cc041a6933988ac",
             "02000000013f7cebd65c27431a90bba7f796914fe8cc2ddfc3f2cbd6f7e5f2fc854534da95000000006b483045022100de1ac3bcdfb0332207c4a91f3832bd2c2915840165f876ab47c5f8996b971c3602201c6c053d750fadde599e6f5c4e1963df0f01fc0d97815e8157e3d59fe09ca30d012103699b464d1d8bc9e47d4fb1cdaa89a1c5783d68363c4dbc4b524ed3d857148617feffffff02836d3c01000000001976a914fc25d6d5c94003bf5b0c7b640a248e2c637fcfb088ac7ada8202000000001976a914fbed3d9b11183209a57999d54d59f67c019e756c88ac6acb0700",
-            0, 0
+            0, 0, vec![], VERIFY_ALL_PRE_TAPROOT
         ).unwrap();
 
         // a random segwit transaction from the blockchain using P2SH
         verify_test (
             "a91434c06f8c87e355e123bdc6dda4ffabc64b6989ef87",
             "01000000000101d9fd94d0ff0026d307c994d0003180a5f248146efb6371d040c5973f5f66d9df0400000017160014b31b31a6cb654cfab3c50567bcf124f48a0beaecffffffff012cbd1c000000000017a914233b74bf0823fa58bbbd26dfc3bb4ae715547167870247304402206f60569cac136c114a58aedd80f6fa1c51b49093e7af883e605c212bdafcd8d202200e91a55f408a021ad2631bc29a67bd6915b2d7e9ef0265627eabd7f7234455f6012103e7e802f50344303c76d12c089c8724c1b230e3b745693bbe16aad536293d15e300000000",
-            1900000, 0
+            1900000, 0, vec![], VERIFY_ALL_PRE_TAPROOT
         ).unwrap();
 
         // a random segwit transaction from the blockchain using native segwit
         verify_test(
             "0020701a8d401c84fb13e6baf169d59684e17abd9fa216c8cc5b9fc63d622ff8c58d",
             "010000000001011f97548fbbe7a0db7588a66e18d803d0089315aa7d4cc28360b6ec50ef36718a0100000000ffffffff02df1776000000000017a9146c002a686959067f4866b8fb493ad7970290ab728757d29f0000000000220020701a8d401c84fb13e6baf169d59684e17abd9fa216c8cc5b9fc63d622ff8c58d04004730440220565d170eed95ff95027a69b313758450ba84a01224e1f7f130dda46e94d13f8602207bdd20e307f062594022f12ed5017bbf4a055a06aea91c10110a0e3bb23117fc014730440220647d2dc5b15f60bc37dc42618a370b2a1490293f9e5c8464f53ec4fe1dfe067302203598773895b4b16d37485cbe21b337f4e4b650739880098c592553add7dd4355016952210375e00eb72e29da82b89367947f29ef34afb75e8654f6ea368e0acdfd92976b7c2103a1b26313f430c4b15bb1fdce663207659d8cac749a0e53d70eff01874496feff2103c96d495bfdd5ba4145e3e046fee45e84a8a48ad05bd8dbb395c011a32cf9f88053ae00000000",
-            18393430 , 0
+            18393430 , 0, vec![], VERIFY_ALL_PRE_TAPROOT
         ).unwrap();
 
         // a random old-style transaction from the blockchain - WITH WRONG SIGNATURE for the address
-        assert!(verify_test (
+        assert!(matches!(verify_test(
             "76a9144bfbaf6afb76cc5771bc6404810d1cc041a6933988ff",
             "02000000013f7cebd65c27431a90bba7f796914fe8cc2ddfc3f2cbd6f7e5f2fc854534da95000000006b483045022100de1ac3bcdfb0332207c4a91f3832bd2c2915840165f876ab47c5f8996b971c3602201c6c053d750fadde599e6f5c4e1963df0f01fc0d97815e8157e3d59fe09ca30d012103699b464d1d8bc9e47d4fb1cdaa89a1c5783d68363c4dbc4b524ed3d857148617feffffff02836d3c01000000001976a914fc25d6d5c94003bf5b0c7b640a248e2c637fcfb088ac7ada8202000000001976a914fbed3d9b11183209a57999d54d59f67c019e756c88ac6acb0700",
-            0, 0
-        ).is_err());
-
-        // a random segwit transaction from the blockchain using P2SH - WITH WRONG AMOUNT
-        assert!(verify_test (
-            "a91434c06f8c87e355e123bdc6dda4ffabc64b6989ef87",
-            "01000000000101d9fd94d0ff0026d307c994d0003180a5f248146efb6371d040c5973f5f66d9df0400000017160014b31b31a6cb654cfab3c50567bcf124f48a0beaecffffffff012cbd1c000000000017a914233b74bf0823fa58bbbd26dfc3bb4ae715547167870247304402206f60569cac136c114a58aedd80f6fa1c51b49093e7af883e605c212bdafcd8d202200e91a55f408a021ad2631bc29a67bd6915b2d7e9ef0265627eabd7f7234455f6012103e7e802f50344303c76d12c089c8724c1b230e3b745693bbe16aad536293d15e300000000",
-            900000, 0).is_err());
+            0, 0 , vec![], VERIFY_ALL_PRE_TAPROOT
+        ), Err(KernelError::ScriptVerify(ScriptVerifyError::Invalid))));
 
         // a random segwit transaction from the blockchain using native segwit - WITH WRONG SEGWIT
-        assert!(verify_test(
+        assert!(matches!(verify_test(
             "0020701a8d401c84fb13e6baf169d59684e17abd9fa216c8cc5b9fc63d622ff8c58f",
             "010000000001011f97548fbbe7a0db7588a66e18d803d0089315aa7d4cc28360b6ec50ef36718a0100000000ffffffff02df1776000000000017a9146c002a686959067f4866b8fb493ad7970290ab728757d29f0000000000220020701a8d401c84fb13e6baf169d59684e17abd9fa216c8cc5b9fc63d622ff8c58d04004730440220565d170eed95ff95027a69b313758450ba84a01224e1f7f130dda46e94d13f8602207bdd20e307f062594022f12ed5017bbf4a055a06aea91c10110a0e3bb23117fc014730440220647d2dc5b15f60bc37dc42618a370b2a1490293f9e5c8464f53ec4fe1dfe067302203598773895b4b16d37485cbe21b337f4e4b650739880098c592553add7dd4355016952210375e00eb72e29da82b89367947f29ef34afb75e8654f6ea368e0acdfd92976b7c2103a1b26313f430c4b15bb1fdce663207659d8cac749a0e53d70eff01874496feff2103c96d495bfdd5ba4145e3e046fee45e84a8a48ad05bd8dbb395c011a32cf9f88053ae00000000",
-            18393430 , 0
-        ).is_err());
+            18393430 , 0, vec![], VERIFY_ALL_PRE_TAPROOT
+        ), Err(KernelError::ScriptVerify(ScriptVerifyError::Invalid))));
 
+        // a random taproot transaction
         let spent = "5120339ce7e165e67d93adb3fef88a6d4beed33f01fa876f05a225242b82a631abc0";
-        let spending = "01000000000101d1f1c1f8cdf6759167b90f52c9ad358a369f95284e841d7a2536cef31c0549580100000000fdffffff020000000000000000316a2f49206c696b65205363686e6f7272207369677320616e6420492063616e6e6f74206c69652e204062697462756734329e06010000000000225120a37c3903c8d0db6512e2b40b0dffa05e5a3ab73603ce8c9c4b7771e5412328f90140a60c383f71bac0ec919b1d7dbc3eb72dd56e7aa99583615564f9f99b8ae4e837b758773a5b2e4c51348854c8389f008e05029db7f464a5ff2e01d5e6e626174affd30a00";
+        let spending  = "01000000000101d1f1c1f8cdf6759167b90f52c9ad358a369f95284e841d7a2536cef31c0549580100000000fdffffff020000000000000000316a2f49206c696b65205363686e6f7272207369677320616e6420492063616e6e6f74206c69652e204062697462756734329e06010000000000225120a37c3903c8d0db6512e2b40b0dffa05e5a3ab73603ce8c9c4b7771e5412328f90140a60c383f71bac0ec919b1d7dbc3eb72dd56e7aa99583615564f9f99b8ae4e837b758773a5b2e4c51348854c8389f008e05029db7f464a5ff2e01d5e6e626174affd30a00";
         let spent_script_pubkey =
             ScriptPubkey::try_from(hex::decode(spent).unwrap().as_slice()).unwrap();
-        let spending_tx = Transaction::new(hex::decode(spending).unwrap().as_slice()).unwrap();
         let outputs: Vec<TxOut> = vec![TxOut::new(&spent_script_pubkey, 88480)];
-        let tx_data = PrecomputedTransactionData::new(&spending_tx, &outputs).unwrap();
-        assert!(verify(
-            &spent_script_pubkey,
-            Some(88480),
-            &spending_tx,
-            0,
-            Some(VERIFY_ALL),
-            &tx_data,
-        )
-        .is_ok());
+        verify_test(spent, spending, 88480, 0, outputs, VERIFY_ALL).unwrap();
+        assert!(matches!(
+            verify_test(spent, spending, 88480, 0, vec![], VERIFY_ALL),
+            Err(KernelError::ScriptVerify(
+                ScriptVerifyError::SpentOutputsRequired
+            ))
+        ));
     }
 
     #[test]
@@ -566,8 +558,9 @@ mod tests {
         spending: &str,
         amount: i64,
         input: usize,
+        outputs: Vec<TxOut>,
+        flags: btck_ScriptVerificationFlags,
     ) -> Result<(), KernelError> {
-        let outputs: Vec<TxOutRef> = vec![];
         let spent_script_pubkey =
             ScriptPubkey::try_from(hex::decode(spent).unwrap().as_slice()).unwrap();
         let spending_tx = Transaction::new(hex::decode(spending).unwrap().as_slice()).unwrap();
@@ -577,7 +570,7 @@ mod tests {
             Some(amount),
             &spending_tx,
             input,
-            Some(VERIFY_ALL_PRE_TAPROOT),
+            Some(flags),
             &tx_data,
         )?;
         Ok(())


### PR DESCRIPTION
This should make it a bit easier to expand the tests in future, and ensures that the invalid scripts actually return an invalid error code.