### PR TITLE
feat(build): replace unwraps by expects with useful messages in build.rs

### DIFF
--- a/libbitcoinkernel-sys/build.rs
+++ b/libbitcoinkernel-sys/build.rs
@@ -42,7 +42,7 @@ fn main() {
         .arg("-DENABLE_IPC=OFF")
         .arg(format!("-DCMAKE_INSTALL_PREFIX={}", install_dir.display()))
         .status()
-        .unwrap();
+        .expect("cmake should be installed and available in PATH");
 
     let num_jobs = env::var("NUM_JOBS")
         .ok()


### PR DESCRIPTION
libbitcoinkernel-sys/build.rs` was executing a cmake binary from the environment and doing some manual flag and path configuration. The presented changes delegate the same job to the cmake crate which should handle dependencies accross environments.

But im not certain if the choice of not using this crate is on purpose.

fix: #135  