### PR TITLE
CI: Use explicit windows version for CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,7 +103,7 @@ jobs:
 
   windows-build:
     name: Build and Test on Windows
-    runs-on: windows-latest
+    runs-on: windows-2025-vs2026
 
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
This is picked up from https://github.com/bitcoin/bitcoin/commit/7164a0cab650bdf01cdcbc3da690f6b674fcc7b3 to prepare for an upcoming change that is not compatible with later msvc versions.