### PR TITLE
fix(script_debug): emit DEBUG_SCRIPT frame for early-exit error paths

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,8 @@ jobs:
       run: |
         # Ensure we're using the right version
         rustc --version
+        # Pin rustc-hash: 2.1.2+ requires rustc 1.77, incompatible with MSRV 1.71.
+        cargo update -p rustc-hash --precise 2.1.1
         # Build the project
         cargo build --all-features
 

--- a/libbitcoinkernel-sys/bitcoin/src/script/interpreter.cpp
+++ b/libbitcoinkernel-sys/bitcoin/src/script/interpreter.cpp
@@ -443,8 +443,13 @@ bool EvalScript(std::vector<std::vector<unsigned char> >& stack, const CScript& 
             //
             // Read instruction
             //
-            if (!script.GetOp(pc, opcode, vchPushValue))
+            if (!script.GetOp(pc, opcode, vchPushValue)) {
+                DEBUG_SCRIPT(stack, script, opcode_pos, altstack, fExec, static_cast<uint8_t>(OP_INVALIDOPCODE), nOpCount, static_cast<uint8_t>(sigversion), execdata.m_tapleaf_hash_init ? execdata.m_tapleaf_hash.data() : nullptr, execdata.m_codeseparator_pos);
                 return set_error(serror, SCRIPT_ERR_BAD_OPCODE);
+            }
+
+            DEBUG_SCRIPT(stack, script, opcode_pos, altstack, fExec, static_cast<uint8_t>(opcode), nOpCount, static_cast<uint8_t>(sigversion), execdata.m_tapleaf_hash_init ? execdata.m_tapleaf_hash.data() : nullptr, execdata.m_codeseparator_pos);
+
             if (vchPushValue.size() > MAX_SCRIPT_ELEMENT_SIZE)
                 return set_error(serror, SCRIPT_ERR_PUSH_SIZE);
 
@@ -454,8 +459,6 @@ bool EvalScript(std::vector<std::vector<unsigned char> >& stack, const CScript& 
                     return set_error(serror, SCRIPT_ERR_OP_COUNT);
                 }
             }
-
-            DEBUG_SCRIPT(stack, script, opcode_pos, altstack, fExec, static_cast<uint8_t>(opcode), nOpCount, static_cast<uint8_t>(sigversion), execdata.m_tapleaf_hash_init ? execdata.m_tapleaf_hash.data() : nullptr, execdata.m_codeseparator_pos);
 
             if (opcode == OP_CAT ||
                 opcode == OP_SUBSTR ||

--- a/src/core/script_debug.rs
+++ b/src/core/script_debug.rs
@@ -234,11 +234,16 @@ impl ScriptTrace {
         let debugger = ScriptDebugger::new(move |frame| {
             frames_clone.lock().unwrap().push(frame);
         })
-        .ok_or_else(|| {
-            KernelError::Internal("script debugger already registered".to_string())
-        })?;
+        .ok_or_else(|| KernelError::Internal("script debugger already registered".to_string()))?;
 
-        let result = verify(script_pubkey, amount, tx_to, input_index, flags, precomputed_txdata);
+        let result = verify(
+            script_pubkey,
+            amount,
+            tx_to,
+            input_index,
+            flags,
+            precomputed_txdata,
+        );
 
         // Drop the debugger to unregister the callback before extracting frames.
         drop(debugger);

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -936,13 +936,27 @@ mod tests {
         assert!(!trace.is_empty(), "trace should have frames");
 
         // Verification passed, so no error
-        assert!(trace.error().is_none(), "successful verification should have no error");
+        assert!(
+            trace.error().is_none(),
+            "successful verification should have no error"
+        );
 
         // Accessors should work
         assert!(trace.get(0).is_some(), "get(0) should return a frame");
-        assert!(trace.get(trace.len()).is_none(), "get(len) should return None");
-        assert_eq!(trace.frames().len(), trace.len(), "frames() and len() should agree");
-        assert_eq!(trace.iter().count(), trace.len(), "iter() count should match len()");
+        assert!(
+            trace.get(trace.len()).is_none(),
+            "get(len) should return None"
+        );
+        assert_eq!(
+            trace.frames().len(),
+            trace.len(),
+            "frames() and len() should agree"
+        );
+        assert_eq!(
+            trace.iter().count(),
+            trace.len(),
+            "iter() count should match len()"
+        );
 
         // First scriptPubKey frame should start with OP_DUP (0x76)
         let p2pkh_script =
@@ -952,7 +966,10 @@ mod tests {
             .filter(|f| f.script == p2pkh_script && f.opcode != 0xff)
             .collect();
         assert!(!p2pkh_frames.is_empty(), "should have P2PKH frames");
-        assert_eq!(p2pkh_frames[0].opcode, 0x76, "first P2PKH opcode should be OP_DUP");
+        assert_eq!(
+            p2pkh_frames[0].opcode, 0x76,
+            "first P2PKH opcode should be OP_DUP"
+        );
     }
 
     #[cfg(feature = "script_debug")]
@@ -965,7 +982,7 @@ mod tests {
         // different scriptPubKey (OP_1 OP_EQUAL), which will fail with EvalFalse
         // since the scriptSig pushes a signature, not 0x01.
         let spent_script_pubkey = ScriptPubkey::try_from(
-            hex::decode("5187").unwrap().as_slice() // OP_1 OP_EQUAL
+            hex::decode("5187").unwrap().as_slice(), // OP_1 OP_EQUAL
         )
         .unwrap();
         let spending_tx = Transaction::new(
@@ -989,10 +1006,16 @@ mod tests {
         .expect("from_verify should succeed even when verification fails");
 
         // Should have captured frames (scriptSig pushes + scriptPubKey execution)
-        assert!(!trace.is_empty(), "trace should have frames even on failure");
+        assert!(
+            !trace.is_empty(),
+            "trace should have frames even on failure"
+        );
 
         // Verification failed, so error should be present
-        assert!(trace.error().is_some(), "failed verification should have an error");
+        assert!(
+            trace.error().is_some(),
+            "failed verification should have an error"
+        );
         assert_eq!(
             *trace.error().unwrap(),
             ScriptError::EvalFalse,
@@ -1035,7 +1058,10 @@ mod tests {
         assert!(!trace.is_empty(), "trace should not be empty");
 
         // get out of bounds
-        assert!(trace.get(usize::MAX).is_none(), "way out of bounds should be None");
+        assert!(
+            trace.get(usize::MAX).is_none(),
+            "way out of bounds should be None"
+        );
 
         // frames() slice length matches len()
         assert_eq!(trace.frames().len(), trace.len());


### PR DESCRIPTION
Three early-return paths in EvalScript exit before the DEBUG_SCRIPT call, so the debugger trace has no frame for the failing step:

  1. `SCRIPT_ERR_BAD_OPCODE` — GetOp() decode failure
  2. `SCRIPT_ERR_PUSH_SIZE` — push data > 520 bytes
  3. `SCRIPT_ERR_OP_COUNT` — >201 non-push opcodes

  Move the main DEBUG_SCRIPT call to right after GetOp() succeeds, and add a dedicated call with OP_INVALIDOPCODE for decode failures.