### PR TITLE
feat(script_debug): add ScriptTrace and expose tapleaf/codesep fields

### DIFF
--- a/examples/src/script_debug.rs
+++ b/examples/src/script_debug.rs
@@ -25,7 +25,7 @@ fn main() {
             _ => "UNKNOWN",
         };
         println!(
-            "\n[step {}] opcode=0x{:02x} ({}) op_count={} sig_version={} f_exec={} stack_depth={}",
+            "\n[step {}] opcode=0x{:02x} ({}) op_count={} sig_version={} f_exec={} stack_depth={} codesep_pos={}",
             frame.opcode_pos,
             frame.opcode,
             opcode_name,
@@ -33,7 +33,11 @@ fn main() {
             sig_version_name,
             frame.f_exec,
             frame.stack.len(),
+            frame.codeseparator_pos,
         );
+        if let Some(hash) = &frame.tapleaf_hash {
+            println!("  Tapleaf hash: 0x{}", hex::encode(hash));
+        }
 
         if !frame.stack.is_empty() {
             println!("  Stack:");

--- a/libbitcoinkernel-sys/bitcoin/src/kernel/bitcoinkernel.cpp
+++ b/libbitcoinkernel-sys/bitcoin/src/kernel/bitcoinkernel.cpp
@@ -1410,7 +1410,9 @@ void btck_register_script_debug_callback(void* user_data, btck_ScriptDebugCallba
                             bool fExec,
                             uint8_t opcode,
                             int nOpCount,
-                            uint8_t sigversion) {
+                            uint8_t sigversion,
+                            const unsigned char* tapleaf_hash,
+                            uint32_t codeseparator_pos) {
         std::vector<const unsigned char*> stack_ptrs;
         std::vector<size_t> stack_sizes;
         stack_ptrs.reserve(stack.size());
@@ -1443,6 +1445,8 @@ void btck_register_script_debug_callback(void* user_data, btck_ScriptDebugCallba
         state.opcode = opcode;
         state.op_count = nOpCount;
         state.sig_version = sigversion;
+        state.tapleaf_hash = tapleaf_hash;
+        state.codeseparator_pos = codeseparator_pos;
 
         callback(user_data, &state);
     };

--- a/libbitcoinkernel-sys/bitcoin/src/kernel/bitcoinkernel.h
+++ b/libbitcoinkernel-sys/bitcoin/src/kernel/bitcoinkernel.h
@@ -1874,6 +1874,8 @@ typedef struct {
     uint8_t opcode;
     int op_count;
     uint8_t sig_version;
+    const unsigned char* tapleaf_hash;
+    uint32_t codeseparator_pos;
 } btck_ScriptDebugState;
 
 /**

--- a/libbitcoinkernel-sys/bitcoin/src/script/debug.cpp
+++ b/libbitcoinkernel-sys/bitcoin/src/script/debug.cpp
@@ -11,11 +11,11 @@
 static std::mutex g_script_debug_mutex;
 static DebugScriptCallback g_script_debug_callback{nullptr};
 
-void DebugScript(std::span<const std::vector<unsigned char>> stack, const CScript& script, uint32_t opcode_pos, std::span<const std::vector<unsigned char>> altstack, bool fExec, uint8_t opcode, int nOpCount, uint8_t sigversion)
+void DebugScript(std::span<const std::vector<unsigned char>> stack, const CScript& script, uint32_t opcode_pos, std::span<const std::vector<unsigned char>> altstack, bool fExec, uint8_t opcode, int nOpCount, uint8_t sigversion, const unsigned char* tapleaf_hash, uint32_t codeseparator_pos)
 {
     std::lock_guard<std::mutex> lock(g_script_debug_mutex);
     if (g_script_debug_callback)
-        g_script_debug_callback(stack, script, opcode_pos, altstack, fExec, opcode, nOpCount, sigversion);
+        g_script_debug_callback(stack, script, opcode_pos, altstack, fExec, opcode, nOpCount, sigversion, tapleaf_hash, codeseparator_pos);
 }
 
 void RegisterDebugScriptCallback(DebugScriptCallback func)

--- a/libbitcoinkernel-sys/bitcoin/src/script/debug.h
+++ b/libbitcoinkernel-sys/bitcoin/src/script/debug.h
@@ -11,17 +11,17 @@
 #include <span>
 #include <vector>
 
-using DebugScriptCallback = std::function<void(std::span<const std::vector<unsigned char>>, const CScript&, uint32_t, std::span<const std::vector<unsigned char>>, bool, uint8_t, int, uint8_t)>;
+using DebugScriptCallback = std::function<void(std::span<const std::vector<unsigned char>>, const CScript&, uint32_t, std::span<const std::vector<unsigned char>>, bool, uint8_t, int, uint8_t, const unsigned char*, uint32_t)>;
 
-void DebugScript(std::span<const std::vector<unsigned char>> stack, const CScript& script, uint32_t opcode_pos, std::span<const std::vector<unsigned char>> altstack, bool fExec, uint8_t opcode, int nOpCount, uint8_t sigversion);
+void DebugScript(std::span<const std::vector<unsigned char>> stack, const CScript& script, uint32_t opcode_pos, std::span<const std::vector<unsigned char>> altstack, bool fExec, uint8_t opcode, int nOpCount, uint8_t sigversion, const unsigned char* tapleaf_hash, uint32_t codeseparator_pos);
 
 void RegisterDebugScriptCallback(DebugScriptCallback func);
 
 #ifdef ENABLE_SCRIPT_DEBUG
-#define DEBUG_SCRIPT(stack, script, opcode_pos, altstack, fExec, opcode, nOpCount, sigversion) \
-    DebugScript(stack, script, opcode_pos, altstack, fExec, opcode, nOpCount, sigversion);
+#define DEBUG_SCRIPT(stack, script, opcode_pos, altstack, fExec, opcode, nOpCount, sigversion, tapleaf_hash, codeseparator_pos) \
+    DebugScript(stack, script, opcode_pos, altstack, fExec, opcode, nOpCount, sigversion, tapleaf_hash, codeseparator_pos);
 #else
-#define DEBUG_SCRIPT(stack, script, opcode_pos, altstack, fExec, opcode, nOpCount, sigversion)
+#define DEBUG_SCRIPT(stack, script, opcode_pos, altstack, fExec, opcode, nOpCount, sigversion, tapleaf_hash, codeseparator_pos)
 #endif // ENABLE_SCRIPT_DEBUG
 
 #endif // BITCOIN_SCRIPT_DEBUG_H

--- a/libbitcoinkernel-sys/bitcoin/src/script/interpreter.cpp
+++ b/libbitcoinkernel-sys/bitcoin/src/script/interpreter.cpp
@@ -455,7 +455,7 @@ bool EvalScript(std::vector<std::vector<unsigned char> >& stack, const CScript& 
                 }
             }
 
-            DEBUG_SCRIPT(stack, script, opcode_pos, altstack, fExec, static_cast<uint8_t>(opcode), nOpCount, static_cast<uint8_t>(sigversion));
+            DEBUG_SCRIPT(stack, script, opcode_pos, altstack, fExec, static_cast<uint8_t>(opcode), nOpCount, static_cast<uint8_t>(sigversion), execdata.m_tapleaf_hash_init ? execdata.m_tapleaf_hash.data() : nullptr, execdata.m_codeseparator_pos);
 
             if (opcode == OP_CAT ||
                 opcode == OP_SUBSTR ||
@@ -1231,7 +1231,7 @@ bool EvalScript(std::vector<std::vector<unsigned char> >& stack, const CScript& 
         return set_error(serror, SCRIPT_ERR_UNKNOWN_ERROR);
     }
 
-    DEBUG_SCRIPT(stack, script, opcode_pos, altstack, vfExec.all_true(), static_cast<uint8_t>(OP_INVALIDOPCODE), nOpCount, static_cast<uint8_t>(sigversion));
+    DEBUG_SCRIPT(stack, script, opcode_pos, altstack, vfExec.all_true(), static_cast<uint8_t>(OP_INVALIDOPCODE), nOpCount, static_cast<uint8_t>(sigversion), execdata.m_tapleaf_hash_init ? execdata.m_tapleaf_hash.data() : nullptr, execdata.m_codeseparator_pos);
 
     if (!vfExec.empty())
         return set_error(serror, SCRIPT_ERR_UNBALANCED_CONDITIONAL);

--- a/src/core/script_debug.rs
+++ b/src/core/script_debug.rs
@@ -63,6 +63,10 @@ pub struct ScriptDebugFrame {
     pub op_count: u32,
     /// Script execution context (legacy, segwit v0, tapscript, etc.).
     pub sig_version: SigVersion,
+    /// Tapleaf hash for tapscript execution, `None` for non-tapscript contexts.
+    pub tapleaf_hash: Option<[u8; 32]>,
+    /// Position of the last executed `OP_CODESEPARATOR`, or `0xFFFFFFFF` if none.
+    pub codeseparator_pos: u32,
 }
 
 /// Guard that keeps a script debug callback registered.
@@ -140,6 +144,15 @@ unsafe extern "C" fn trampoline(
 
         let sig_version = SigVersion::try_from(state.sig_version).unwrap_or(SigVersion::Base);
 
+        let tapleaf_hash = if state.tapleaf_hash.is_null() {
+            None
+        } else {
+            let bytes = unsafe { std::slice::from_raw_parts(state.tapleaf_hash, 32) };
+            let mut hash = [0u8; 32];
+            hash.copy_from_slice(bytes);
+            Some(hash)
+        };
+
         let frame = ScriptDebugFrame {
             stack,
             altstack,
@@ -149,6 +162,8 @@ unsafe extern "C" fn trampoline(
             opcode: state.opcode,
             op_count: state.op_count as u32,
             sig_version,
+            tapleaf_hash,
+            codeseparator_pos: state.codeseparator_pos,
         };
 
         let closure = unsafe { &mut **(user_data as *mut Box<dyn FnMut(ScriptDebugFrame)>) };

--- a/src/core/script_debug.rs
+++ b/src/core/script_debug.rs
@@ -4,12 +4,18 @@
 //! inspection of stack state at each opcode during script verification.
 
 use std::panic;
-use std::sync::Mutex;
+use std::sync::{Arc, Mutex};
 
 use libbitcoinkernel_sys::{
     btck_ScriptDebugState, btck_register_script_debug_callback,
     btck_unregister_script_debug_callback,
 };
+
+use crate::core::verify::{ScriptError, ScriptVerifyError};
+use crate::core::{verify, PrecomputedTransactionData};
+use crate::KernelError;
+use crate::ScriptPubkeyExt;
+use crate::TransactionExt;
 
 /// Script execution context (signature version).
 ///
@@ -189,4 +195,100 @@ unsafe fn read_stack(items: *const *const u8, sizes: *const usize, count: usize)
             }
         })
         .collect()
+}
+
+/// A complete recording of script execution, captured by running verification
+/// and collecting every [`ScriptDebugFrame`] emitted by the interpreter.
+///
+/// Frames are indexed by step number (0-based). Verification failures are
+/// recorded in [`error()`](ScriptTrace::error), not propagated as `Err`.
+pub struct ScriptTrace {
+    frames: Vec<ScriptDebugFrame>,
+    script_error: Option<ScriptError>,
+}
+
+impl ScriptTrace {
+    /// Capture a trace by running script verification on a transaction input.
+    ///
+    /// Registers a temporary debug callback, runs [`verify()`], and collects
+    /// every frame. Returns the complete trace regardless of whether
+    /// verification passed or failed.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Err` if a debugger is already registered or if `verify()`
+    /// encounters a setup error (invalid flags, bad input index, etc.).
+    /// Script execution failure is **not** an error — it produces a trace
+    /// with [`error()`](Self::error) returning `Some`.
+    pub fn from_verify(
+        script_pubkey: &impl ScriptPubkeyExt,
+        amount: Option<i64>,
+        tx_to: &impl TransactionExt,
+        input_index: usize,
+        flags: Option<u32>,
+        precomputed_txdata: &PrecomputedTransactionData,
+    ) -> Result<Self, KernelError> {
+        let frames: Arc<Mutex<Vec<ScriptDebugFrame>>> = Arc::new(Mutex::new(Vec::new()));
+        let frames_clone = frames.clone();
+
+        let debugger = ScriptDebugger::new(move |frame| {
+            frames_clone.lock().unwrap().push(frame);
+        })
+        .ok_or_else(|| {
+            KernelError::Internal("script debugger already registered".to_string())
+        })?;
+
+        let result = verify(script_pubkey, amount, tx_to, input_index, flags, precomputed_txdata);
+
+        // Drop the debugger to unregister the callback before extracting frames.
+        drop(debugger);
+
+        let collected = Arc::try_unwrap(frames)
+            .expect("debugger dropped, no other Arc refs")
+            .into_inner()
+            .unwrap();
+
+        let script_error = match result {
+            Ok(()) => None,
+            Err(KernelError::ScriptVerify(ScriptVerifyError::Script(se))) => Some(se),
+            Err(e) => return Err(e),
+        };
+
+        Ok(ScriptTrace {
+            frames: collected,
+            script_error,
+        })
+    }
+
+    /// Number of steps in the trace.
+    pub fn len(&self) -> usize {
+        self.frames.len()
+    }
+
+    /// Whether the trace is empty.
+    pub fn is_empty(&self) -> bool {
+        self.frames.is_empty()
+    }
+
+    /// Get the frame at step `index`, or `None` if out of bounds.
+    pub fn get(&self, index: usize) -> Option<&ScriptDebugFrame> {
+        self.frames.get(index)
+    }
+
+    /// Iterate over all frames in order.
+    pub fn iter(&self) -> impl Iterator<Item = &ScriptDebugFrame> {
+        self.frames.iter()
+    }
+
+    /// The full slice of frames.
+    pub fn frames(&self) -> &[ScriptDebugFrame] {
+        &self.frames
+    }
+
+    /// The script execution error, if verification failed.
+    ///
+    /// Returns `None` if verification passed.
+    pub fn error(&self) -> Option<&ScriptError> {
+        self.script_error.as_ref()
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -316,7 +316,7 @@ pub use crate::state::{
 };
 
 #[cfg(feature = "script_debug")]
-pub use crate::core::script_debug::{ScriptDebugFrame, ScriptDebugger, SigVersion};
+pub use crate::core::script_debug::{ScriptDebugFrame, ScriptDebugger, ScriptTrace, SigVersion};
 
 pub use crate::core::verify_flags::{
     VERIFY_ALL, VERIFY_ALL_PRE_TAPROOT, VERIFY_CHECKLOCKTIMEVERIFY, VERIFY_CHECKSEQUENCEVERIFY,

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -745,6 +745,22 @@ mod tests {
                 "P2PKH execution should use SigVersion::Base"
             );
         }
+
+        // P2PKH (non-tapscript) should have no tapleaf hash
+        for frame in collected.iter() {
+            assert_eq!(
+                frame.tapleaf_hash, None,
+                "P2PKH frames should have no tapleaf hash"
+            );
+        }
+
+        // codeseparator_pos should be 0xFFFFFFFF (no OP_CODESEPARATOR executed)
+        for frame in collected.iter() {
+            assert_eq!(
+                frame.codeseparator_pos, 0xFFFFFFFF,
+                "P2PKH frames should have codeseparator_pos = 0xFFFFFFFF"
+            );
+        }
     }
 
     /// Multiple threads race to register a debugger — at most one should be active at a time.

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -901,6 +901,153 @@ mod tests {
         );
     }
 
+    #[cfg(feature = "script_debug")]
+    #[test]
+    fn test_script_trace_from_verify() {
+        use bitcoinkernel::{ScriptTrace, VERIFY_ALL_PRE_TAPROOT};
+
+        let spent_script_pubkey = ScriptPubkey::try_from(
+            hex::decode("76a9144bfbaf6afb76cc5771bc6404810d1cc041a6933988ac")
+                .unwrap()
+                .as_slice(),
+        )
+        .unwrap();
+        let spending_tx = Transaction::new(
+            hex::decode(
+                "02000000013f7cebd65c27431a90bba7f796914fe8cc2ddfc3f2cbd6f7e5f2fc854534da95000000006b483045022100de1ac3bcdfb0332207c4a91f3832bd2c2915840165f876ab47c5f8996b971c3602201c6c053d750fadde599e6f5c4e1963df0f01fc0d97815e8157e3d59fe09ca30d012103699b464d1d8bc9e47d4fb1cdaa89a1c5783d68363c4dbc4b524ed3d857148617feffffff02836d3c01000000001976a914fc25d6d5c94003bf5b0c7b640a248e2c637fcfb088ac7ada8202000000001976a914fbed3d9b11183209a57999d54d59f67c019e756c88ac6acb0700",
+            )
+            .unwrap()
+            .as_slice(),
+        )
+        .unwrap();
+        let tx_data = PrecomputedTransactionData::new(&spending_tx, &Vec::<TxOut>::new()).unwrap();
+
+        let trace = ScriptTrace::from_verify(
+            &spent_script_pubkey,
+            Some(0),
+            &spending_tx,
+            0,
+            Some(VERIFY_ALL_PRE_TAPROOT),
+            &tx_data,
+        )
+        .expect("from_verify should succeed");
+
+        // Should have captured frames
+        assert!(!trace.is_empty(), "trace should have frames");
+
+        // Verification passed, so no error
+        assert!(trace.error().is_none(), "successful verification should have no error");
+
+        // Accessors should work
+        assert!(trace.get(0).is_some(), "get(0) should return a frame");
+        assert!(trace.get(trace.len()).is_none(), "get(len) should return None");
+        assert_eq!(trace.frames().len(), trace.len(), "frames() and len() should agree");
+        assert_eq!(trace.iter().count(), trace.len(), "iter() count should match len()");
+
+        // First scriptPubKey frame should start with OP_DUP (0x76)
+        let p2pkh_script =
+            hex::decode("76a9144bfbaf6afb76cc5771bc6404810d1cc041a6933988ac").unwrap();
+        let p2pkh_frames: Vec<_> = trace
+            .iter()
+            .filter(|f| f.script == p2pkh_script && f.opcode != 0xff)
+            .collect();
+        assert!(!p2pkh_frames.is_empty(), "should have P2PKH frames");
+        assert_eq!(p2pkh_frames[0].opcode, 0x76, "first P2PKH opcode should be OP_DUP");
+    }
+
+    #[cfg(feature = "script_debug")]
+    #[test]
+    fn test_script_trace_from_verify_failure() {
+        use bitcoinkernel::{ScriptError, ScriptTrace, VERIFY_ALL_PRE_TAPROOT};
+
+        // Use a valid P2PKH scriptPubKey but a transaction with a bad signature.
+        // We construct this by using the correct tx but verifying against a
+        // different scriptPubKey (OP_1 OP_EQUAL), which will fail with EvalFalse
+        // since the scriptSig pushes a signature, not 0x01.
+        let spent_script_pubkey = ScriptPubkey::try_from(
+            hex::decode("5187").unwrap().as_slice() // OP_1 OP_EQUAL
+        )
+        .unwrap();
+        let spending_tx = Transaction::new(
+            hex::decode(
+                "02000000013f7cebd65c27431a90bba7f796914fe8cc2ddfc3f2cbd6f7e5f2fc854534da95000000006b483045022100de1ac3bcdfb0332207c4a91f3832bd2c2915840165f876ab47c5f8996b971c3602201c6c053d750fadde599e6f5c4e1963df0f01fc0d97815e8157e3d59fe09ca30d012103699b464d1d8bc9e47d4fb1cdaa89a1c5783d68363c4dbc4b524ed3d857148617feffffff02836d3c01000000001976a914fc25d6d5c94003bf5b0c7b640a248e2c637fcfb088ac7ada8202000000001976a914fbed3d9b11183209a57999d54d59f67c019e756c88ac6acb0700",
+            )
+            .unwrap()
+            .as_slice(),
+        )
+        .unwrap();
+        let tx_data = PrecomputedTransactionData::new(&spending_tx, &Vec::<TxOut>::new()).unwrap();
+
+        let trace = ScriptTrace::from_verify(
+            &spent_script_pubkey,
+            Some(0),
+            &spending_tx,
+            0,
+            Some(VERIFY_ALL_PRE_TAPROOT),
+            &tx_data,
+        )
+        .expect("from_verify should succeed even when verification fails");
+
+        // Should have captured frames (scriptSig pushes + scriptPubKey execution)
+        assert!(!trace.is_empty(), "trace should have frames even on failure");
+
+        // Verification failed, so error should be present
+        assert!(trace.error().is_some(), "failed verification should have an error");
+        assert_eq!(
+            *trace.error().unwrap(),
+            ScriptError::EvalFalse,
+            "error should be EvalFalse"
+        );
+    }
+
+    #[cfg(feature = "script_debug")]
+    #[test]
+    fn test_script_trace_accessors() {
+        use bitcoinkernel::{ScriptTrace, VERIFY_ALL_PRE_TAPROOT};
+
+        let spent_script_pubkey = ScriptPubkey::try_from(
+            hex::decode("76a9144bfbaf6afb76cc5771bc6404810d1cc041a6933988ac")
+                .unwrap()
+                .as_slice(),
+        )
+        .unwrap();
+        let spending_tx = Transaction::new(
+            hex::decode(
+                "02000000013f7cebd65c27431a90bba7f796914fe8cc2ddfc3f2cbd6f7e5f2fc854534da95000000006b483045022100de1ac3bcdfb0332207c4a91f3832bd2c2915840165f876ab47c5f8996b971c3602201c6c053d750fadde599e6f5c4e1963df0f01fc0d97815e8157e3d59fe09ca30d012103699b464d1d8bc9e47d4fb1cdaa89a1c5783d68363c4dbc4b524ed3d857148617feffffff02836d3c01000000001976a914fc25d6d5c94003bf5b0c7b640a248e2c637fcfb088ac7ada8202000000001976a914fbed3d9b11183209a57999d54d59f67c019e756c88ac6acb0700",
+            )
+            .unwrap()
+            .as_slice(),
+        )
+        .unwrap();
+        let tx_data = PrecomputedTransactionData::new(&spending_tx, &Vec::<TxOut>::new()).unwrap();
+
+        let trace = ScriptTrace::from_verify(
+            &spent_script_pubkey,
+            Some(0),
+            &spending_tx,
+            0,
+            Some(VERIFY_ALL_PRE_TAPROOT),
+            &tx_data,
+        )
+        .unwrap();
+
+        // is_empty
+        assert!(!trace.is_empty(), "trace should not be empty");
+
+        // get out of bounds
+        assert!(trace.get(usize::MAX).is_none(), "way out of bounds should be None");
+
+        // frames() slice length matches len()
+        assert_eq!(trace.frames().len(), trace.len());
+
+        // iter yields same frames as get()
+        for (i, frame) in trace.iter().enumerate() {
+            let got = trace.get(i).unwrap();
+            assert_eq!(got.opcode_pos, frame.opcode_pos);
+            assert_eq!(got.opcode, frame.opcode);
+        }
+    }
+
     #[test]
     fn test_traits() {
         fn is_sync<T: Sync>() {}


### PR DESCRIPTION
Expose `tapleaf_hash` and `codeseparator_pos` in the debug callback for tapscript sighash debugging, and add `ScriptTrace`, which is a high-level wrapper that captures a complete execution trace via `from_verify()` with indexed random-access to every frame.