### PR TITLE
ci: add weekly cron job to run all tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,8 @@ name: Rust CI
 on:
   push:
   pull_request:
+  schedule:
+    - cron: '0 0 * * 1' # weekly on Monday at midnight UTC
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
Addresses https://github.com/sedited/rust-bitcoinkernel/issues/152

### Summary

This PR adds a weekly cron job that runs every Monday at midnight UTC.

### Motivation

Actively seek out MSRV breakages.