### PR TITLE
feat(core): expose BlockTreeEntry::ancestor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Added `BlockTreeEntry::ancestor` to look up an ancestor block at a given height. Returns `None` if the height is out of range. This operation is O(log N).
+
 ## [0.2.0] 2026-01-26
 
 ### Added

--- a/src/core/block_tree_entry.rs
+++ b/src/core/block_tree_entry.rs
@@ -1,7 +1,7 @@
 use std::marker::PhantomData;
 
 use libbitcoinkernel_sys::{
-    btck_BlockTreeEntry, btck_block_tree_entry_get_block_hash,
+    btck_BlockTreeEntry, btck_block_tree_entry_get_ancestor, btck_block_tree_entry_get_block_hash,
     btck_block_tree_entry_get_block_header, btck_block_tree_entry_get_height,
     btck_block_tree_entry_get_previous,
 };
@@ -54,6 +54,21 @@ impl<'a> BlockTreeEntry<'a> {
     pub fn block_hash(&self) -> BlockHashRef<'_> {
         let hash_ptr = unsafe { btck_block_tree_entry_get_block_hash(self.inner) };
         unsafe { BlockHashRef::from_ptr(hash_ptr) }
+    }
+
+    /// Returns the ancestor at `height`, or `None` if `height < 0` or
+    /// `height > self.height()`.
+    ///
+    /// This operation is O(log N).
+    pub fn ancestor(&self, height: i32) -> Option<BlockTreeEntry<'a>> {
+        if height < 0 || height > self.height() {
+            return None;
+        }
+        let ptr = unsafe { btck_block_tree_entry_get_ancestor(self.inner, height) };
+        if ptr.is_null() {
+            return None;
+        }
+        Some(unsafe { BlockTreeEntry::from_ptr(ptr) })
     }
 }
 

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -705,6 +705,11 @@ mod tests {
 
         assert_eq!(last_height, tip_height as usize);
         assert_eq!(last_block_index.unwrap().block_hash(), tip_hash);
+
+        assert_eq!(tip.ancestor(tip_height).unwrap().block_hash(), tip_hash);
+        assert_eq!(tip.ancestor(0).unwrap().block_hash(), genesis_hash);
+        assert!(tip.ancestor(-1).is_none());
+        assert!(tip.ancestor(tip_height + 1).is_none());
     }
 
     #[test]


### PR DESCRIPTION
Exposes btck_block_tree_entry_get_ancestor as BlockTreeEntry::ancestor in the Rust bindings. Returns Option<BlockTreeEntry> and guards against height < 0 or height > self.height() before calling into the C API.

Closes #162.