### PR TITLE
fix(core): use &self in BlockTreeEntry::prev for consistency

### DIFF
--- a/src/core/block_tree_entry.rs
+++ b/src/core/block_tree_entry.rs
@@ -30,7 +30,7 @@ unsafe impl Sync for BlockTreeEntry<'_> {}
 impl<'a> BlockTreeEntry<'a> {
     /// Move to the previous entry in the block tree. E.g. from height n to
     /// height n-1.
-    pub fn prev(self) -> Option<BlockTreeEntry<'a>> {
+    pub fn prev(&self) -> Option<BlockTreeEntry<'a>> {
         let inner = unsafe { btck_block_tree_entry_get_previous(self.inner) };
 
         if inner.is_null() {


### PR DESCRIPTION
### Motivation

All other methods take `&self`. `BlockTreeEntry`s are `Copy`, so the values are never actually consumed, but are just copied.