### PR TITLE
chore(ci): add lock file check job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,20 @@ jobs:
     - name: Run tests with MSRV
       run: cargo test --all-features --locked
 
+  check-lock-files:
+    name: Check lock files
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Install Rust nightly
+      uses: dtolnay/rust-toolchain@nightly
+
+    - name: Check Cargo-minimal.lock
+      run: |
+        cargo +nightly update -Z minimal-versions
+        git diff --exit-code Cargo-minimal.lock
+
   build:
     name: Build and Test
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -44,6 +44,17 @@ resolution:
 cargo build --locked
 ```
 
+## Lock files
+
+`Cargo-minimal.lock` and `Cargo-recent.lock` pin dependencies to their minimum
+and most recent compatible versions.
+
+To regenerate them run:
+
+```bash
+./contrib/update_lock_files.sh
+```
+
 ## Documentation
 
 You can find detailed information about the library on its

--- a/contrib/update_lock_files.sh
+++ b/contrib/update_lock_files.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -e
+
+echo "Generating Cargo-minimal.lock..."
+cargo +nightly update -Z minimal-versions
+cp Cargo.lock Cargo-minimal.lock
+
+echo "Generating Cargo-recent.lock..."
+cargo update
+cp Cargo.lock Cargo-recent.lock
+
+echo "Done."


### PR DESCRIPTION
### Summary

Adds a CI job to check the minimal lock file and detect drift. Only cargo-minimal.lock is checked since Cargo-recent.lock drifts with every new crate release, making it too noisy to enforce in CI.

### Motivation

Removes the need to run the commands locally to verify changes are correct.