### PR TITLE
chore(pr-check): add pull request checks workflow to verify CHANGELOG.md

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -1,0 +1,28 @@
+name: Pull Request Checks
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
+
+jobs:
+  changelog-check:
+    name: Verify CHANGELOG.md was modified
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Verify CHANGELOG.md was modified
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          LABELS: ${{ toJson(github.event.pull_request.labels.*.name) }}
+        run: |
+          if echo "$LABELS" | grep -q "no-changelog"; then
+            echo "Skipping changelog check (no-changelog label)"
+            exit 0
+          fi
+          if git diff --name-only $BASE_SHA...HEAD \
+            | grep -qE "(^|/)CHANGELOG\.md$"; then
+            echo "CHANGELOG.md was modified"
+            exit 0
+          fi
+          echo "ERROR: CHANGELOG.md not modified. Update the changelog or ask a maintainer to apply the 'no-changelog' label."
+          exit 1


### PR DESCRIPTION
### Summary

This PR adds a `pr-checks.yml` workflow to ensure `CHANGELOG.md` has been updated. Maintainers can apply the `no-changelog` label to bypass this test.

### Motivation

Contributors often forget to update the `CHANGELOG` file. The `no-changelog` label serves as a workaround when no CHANGELOG edits are required without asking any further contributions or edits from a PR author.
The check lives in a separate workflow from `ci.yml` to avoid all checks from running when adding or removing a label

### Usage
1. Apply the `no-changelog` label and the PR checks workflow will rerun.
2. Remove the `no-changelog` label and the PR checks workflow will rerun once more.