### PR TITLE
fix(pr-checks): fetch full git history in PR checkout for changelog diff

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -10,6 +10,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
       - name: Verify CHANGELOG.md was modified
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}


### PR DESCRIPTION
### Summary
The changelog CI check was failing intermittently with: 
```
fatal: Invalid symmetric difference expression 578acd2a...HEAD
```
This was caused by `actions/checkout` defaulting to a shallow clone (depth 1) and the base commit not being available for the diff.

### Changes

- Add `fetch-depth: 0` to the checkout step for the full history

### Why did this work earlier?

The only explanation I currently have is that the CI runners were reused and had history cached locally. 

### How was this tested?
Applied the same fix to extend a failing branch https://github.com/sedited/rust-bitcoinkernel/pull/174 and confirmed the CI passed.