### PR TITLE
refactor(ffi): add `AsMutPtr` trait and replace implicit const-to-mut pointer cast

### DIFF
--- a/src/ffi/mod.rs
+++ b/src/ffi/mod.rs
@@ -9,6 +9,11 @@ pub(crate) mod sealed {
         fn as_ptr(&self) -> *const T;
     }
 
+    pub trait AsMutPtr<T> {
+        /// Returns a raw mutable pointer to the underlying C object.
+        fn as_mut_ptr(&self) -> *mut T;
+    }
+
     pub trait FromPtr<T> {
         /// Creates a wrapper from a raw const C pointer.
         unsafe fn from_ptr(ptr: *const T) -> Self;

--- a/src/notifications/types.rs
+++ b/src/notifications/types.rs
@@ -9,7 +9,7 @@ use libbitcoinkernel_sys::{
 };
 
 use crate::{
-    ffi::sealed::{AsPtr, FromMutPtr, FromPtr},
+    ffi::sealed::{AsMutPtr, AsPtr, FromMutPtr, FromPtr},
     BTCK_BLOCK_VALIDATION_RESULT_CACHED_INVALID, BTCK_BLOCK_VALIDATION_RESULT_CONSENSUS,
     BTCK_BLOCK_VALIDATION_RESULT_HEADER_LOW_WORK, BTCK_BLOCK_VALIDATION_RESULT_INVALID_HEADER,
     BTCK_BLOCK_VALIDATION_RESULT_INVALID_PREV, BTCK_BLOCK_VALIDATION_RESULT_MISSING_PREV,
@@ -211,6 +211,12 @@ impl BlockValidationState {
 impl AsPtr<btck_BlockValidationState> for BlockValidationState {
     fn as_ptr(&self) -> *const btck_BlockValidationState {
         self.inner as *const _
+    }
+}
+
+impl AsMutPtr<btck_BlockValidationState> for BlockValidationState {
+    fn as_mut_ptr(&self) -> *mut btck_BlockValidationState {
+        self.inner
     }
 }
 

--- a/src/state/chainstate.rs
+++ b/src/state/chainstate.rs
@@ -28,9 +28,8 @@
 use std::ffi::CString;
 
 use libbitcoinkernel_sys::{
-    btck_BlockHash, btck_BlockValidationState, btck_ChainstateManager,
-    btck_ChainstateManagerOptions, btck_block_read, btck_block_spent_outputs_read,
-    btck_chainstate_manager_create, btck_chainstate_manager_destroy,
+    btck_BlockHash, btck_ChainstateManager, btck_ChainstateManagerOptions, btck_block_read,
+    btck_block_spent_outputs_read, btck_chainstate_manager_create, btck_chainstate_manager_destroy,
     btck_chainstate_manager_get_active_chain, btck_chainstate_manager_get_best_entry,
     btck_chainstate_manager_get_block_tree_entry_by_hash, btck_chainstate_manager_import_blocks,
     btck_chainstate_manager_options_create, btck_chainstate_manager_options_destroy,
@@ -45,7 +44,7 @@ use crate::{
     core::block::BlockHeader,
     ffi::{
         c_helpers,
-        sealed::{AsPtr, FromMutPtr, FromPtr},
+        sealed::{AsMutPtr, AsPtr, FromMutPtr, FromPtr},
     },
     notifications::types::BlockValidationState,
     Block, BlockHash, BlockSpentOutputs, BlockTreeEntry, KernelError,
@@ -311,7 +310,7 @@ impl ChainstateManager {
             btck_chainstate_manager_process_block_header(
                 self.inner,
                 header.as_ptr(),
-                state.as_ptr() as *mut btck_BlockValidationState,
+                state.as_mut_ptr(),
             )
         };
         if c_helpers::success(processed) {


### PR DESCRIPTION
### Changes

- Introduce AsMutPtr<T> to the sealed FFI trait module to properly express mutable pointer access. 
- Implement AsMutPtr for BlockValidationState (owned, *mut) but not BlockValidationStateRef (borrowed, *const)
- Replaces the `as_ptr() as *mut` cast in process_block_header with the `as_mut_ptr()` call

### Motivation

The `as_ptr() as *mut` cast worked because BlockValidationState owns a *mut internally, making it a safe roundtrip. Leaving this pattern in the codebase sets a precedent that could be copied onto types which hold a genuine *const, where casting to *mut and mutating through it would be UB.