### PR TITLE
chore(workflow): upgrade CI actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,11 +69,8 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Install Rust toolchain
-      uses: actions-rs/toolchain@v1
+      uses: dtolnay/rust-toolchain@stable
       with:
-        profile: minimal
-        toolchain: stable
-        override: true
         components: rustfmt
 
     - name: Cache dependencies
@@ -132,12 +129,7 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Install Rust toolchain
-      uses: actions-rs/toolchain@v1
-      with:
-        profile: minimal
-        toolchain: stable
-        override: true
-        components: rustfmt
+      uses: dtolnay/rust-toolchain@stable
 
     - name: Cache dependencies
       uses: Swatinem/rust-cache@v2
@@ -168,12 +160,7 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Install Rust toolchain
-      uses: actions-rs/toolchain@v1
-      with:
-        profile: minimal
-        toolchain: stable
-        override: true
-        components: rustfmt
+      uses: dtolnay/rust-toolchain@stable
 
     - name: Cache dependencies
       uses: Swatinem/rust-cache@v2
@@ -194,12 +181,7 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Install Rust toolchain
-      uses: actions-rs/toolchain@v1
-      with:
-        profile: minimal
-        toolchain: stable
-        override: true
-        components: rustfmt
+      uses: dtolnay/rust-toolchain@stable
 
     - name: Cache dependencies
       uses: Swatinem/rust-cache@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
       matrix:
         dep: [minimal, recent]
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Install Rust MSRV
       uses: dtolnay/rust-toolchain@master
@@ -51,7 +51,7 @@ jobs:
     name: Check lock files
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Install Rust nightly
       uses: dtolnay/rust-toolchain@nightly
@@ -66,7 +66,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Install Rust toolchain
       uses: actions-rs/toolchain@v1
@@ -129,7 +129,7 @@ jobs:
     runs-on: windows-2025-vs2026
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Install Rust toolchain
       uses: actions-rs/toolchain@v1
@@ -165,7 +165,7 @@ jobs:
     runs-on: ubuntu-24.04-arm
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Install Rust toolchain
       uses: actions-rs/toolchain@v1
@@ -191,7 +191,7 @@ jobs:
     runs-on: macos-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Install Rust toolchain
       uses: actions-rs/toolchain@v1
@@ -226,10 +226,10 @@ jobs:
 
     steps:
       - name: Checkout rust-bitcoinkernel
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Checkout qa-assets corpus
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: alexanderwiederin/qa-assets
           path: qa-assets

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -9,7 +9,7 @@ jobs:
     name: Verify CHANGELOG.md was modified
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Verify CHANGELOG.md was modified


### PR DESCRIPTION
### Changes

- Replaces `actions-rs/toolchain@v1` with `dtolnay/rust-toolchain` 
- Upgrades `actions/checkout` from `v3` to `v4`.

### Motivation

- `actions-rs/toolchain@v1` is abandoned and was the likely cause of intermittent CI failures: `error: unexpected argument 'test' found.`
- `actions/checkout@v3` is no longer being maintained. 