### PR TITLE
chore(ci): add nixfmt and statix checks for flake.nix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,6 +77,9 @@ jobs:
     - name: Check Nix formatting (nixfmt)
       run: nix run nixpkgs#nixfmt -- --check flake.nix
 
+    - name: Lint Nix files (statix)
+      run: nix run nixpkgs#statix -- check flake.nix
+
     - name: Set Cargo.lock
       run: cp Cargo-minimal.lock Cargo.lock
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,6 +74,9 @@ jobs:
     - name: Check flake
       run: nix flake check
 
+    - name: Check Nix formatting (nixfmt)
+      run: nix run nixpkgs#nixfmt -- --check flake.nix
+
     - name: Set Cargo.lock
       run: cp Cargo-minimal.lock Cargo.lock
 

--- a/flake.nix
+++ b/flake.nix
@@ -1,82 +1,90 @@
 {
-	description = "rust-bitcoinkernel";
+  description = "rust-bitcoinkernel";
 
-	inputs = {
-		nixpkgs.url = "nixpkgs/nixos-25.05";
-		flake-utils.url = "github:numtide/flake-utils";
-		fenix = {
-			url = "github:nix-community/fenix";
-			inputs.nixpkgs.follows = "nixpkgs";
-		};
-	};
+  inputs = {
+    nixpkgs.url = "nixpkgs/nixos-25.05";
+    flake-utils.url = "github:numtide/flake-utils";
+    fenix = {
+      url = "github:nix-community/fenix";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+  };
 
-	outputs = { self, nixpkgs, flake-utils, fenix }:
-		flake-utils.lib.eachDefaultSystem (system:
-			let
-				pkgs = import nixpkgs {
-					inherit system;
-				};
+  outputs =
+    {
+      self,
+      nixpkgs,
+      flake-utils,
+      fenix,
+    }:
+    flake-utils.lib.eachDefaultSystem (
+      system:
+      let
+        pkgs = import nixpkgs {
+          inherit system;
+        };
 
-				rustVersion = "1.71.0";
-				rustToolchain = fenix.packages.${system}.fromToolchainName {
-					name = rustVersion;
-					sha256 = "sha256-ks0nMEGGXKrHnfv4Fku+vhQ7gx76ruv6Ij4fKZR3l78=";
-				};
-				rustBuildToolchain = fenix.packages.${system}.combine [
-					rustToolchain.rustc
-					rustToolchain.cargo
-					rustToolchain.rust-src
-					rustToolchain.rust-std
-				];
+        rustVersion = "1.71.0";
+        rustToolchain = fenix.packages.${system}.fromToolchainName {
+          name = rustVersion;
+          sha256 = "sha256-ks0nMEGGXKrHnfv4Fku+vhQ7gx76ruv6Ij4fKZR3l78=";
+        };
+        rustBuildToolchain = fenix.packages.${system}.combine [
+          rustToolchain.rustc
+          rustToolchain.cargo
+          rustToolchain.rust-src
+          rustToolchain.rust-std
+        ];
 
-				rustBuildToolchainNightly = fenix.packages.${system}.latest.toolchain;
+        rustBuildToolchainNightly = fenix.packages.${system}.latest.toolchain;
 
-				rustPlatformNightly = pkgs.makeRustPlatform {
-					cargo = rustBuildToolchainNightly;
-					rustc = rustBuildToolchainNightly;
-				};
-				rustfilt = rustPlatformNightly.buildRustPackage rec {
-					pname = "rustfilt";
-					version = "0.2.1";
-					src = pkgs.fetchFromGitHub {
-						owner = "luser";
-						repo = "rustfilt";
-						rev = version;
-						hash = "sha256-zb1tkeWmeMq7aM8hWssS/UpvGzGbfsaVYCOKBnAKwiQ=";
-					};
-					cargoLock.lockFile = "${src}/Cargo.lock";
-				};
-			in {
-				devShells.default = pkgs.mkShell {
-					packages = [
-						rustBuildToolchain
+        rustPlatformNightly = pkgs.makeRustPlatform {
+          cargo = rustBuildToolchainNightly;
+          rustc = rustBuildToolchainNightly;
+        };
+        rustfilt = rustPlatformNightly.buildRustPackage rec {
+          pname = "rustfilt";
+          version = "0.2.1";
+          src = pkgs.fetchFromGitHub {
+            owner = "luser";
+            repo = "rustfilt";
+            rev = version;
+            hash = "sha256-zb1tkeWmeMq7aM8hWssS/UpvGzGbfsaVYCOKBnAKwiQ=";
+          };
+          cargoLock.lockFile = "${src}/Cargo.lock";
+        };
+      in
+      {
+        devShells.default = pkgs.mkShell {
+          packages = [
+            rustBuildToolchain
 
-						pkgs.cmake
-						pkgs.boost.dev
-						pkgs.cargo-fuzz
-					];
+            pkgs.cmake
+            pkgs.boost.dev
+            pkgs.cargo-fuzz
+          ];
 
-					LIBCLANG_PATH = "${pkgs.llvmPackages.clang-unwrapped.lib}/lib/";
-				};
+          LIBCLANG_PATH = "${pkgs.llvmPackages.clang-unwrapped.lib}/lib/";
+        };
 
-				devShells.nightly = pkgs.mkShell {
-					packages = [
-						rustBuildToolchainNightly
+        devShells.nightly = pkgs.mkShell {
+          packages = [
+            rustBuildToolchainNightly
 
-						pkgs.cmake
-						pkgs.boost.dev
-						pkgs.cargo-fuzz
+            pkgs.cmake
+            pkgs.boost.dev
+            pkgs.cargo-fuzz
 
-						pkgs.libllvm
-						pkgs.cargo-llvm-cov
-						rustfilt
-					];
+            pkgs.libllvm
+            pkgs.cargo-llvm-cov
+            rustfilt
+          ];
 
-					LIBCLANG_PATH = "${pkgs.llvmPackages.clang-unwrapped.lib}/lib/";
-					LD_LIBRARY_PATH = pkgs.lib.makeLibraryPath [
-						pkgs.gcc.cc.lib
-					];
-				};
-			}
-		);
+          LIBCLANG_PATH = "${pkgs.llvmPackages.clang-unwrapped.lib}/lib/";
+          LD_LIBRARY_PATH = pkgs.lib.makeLibraryPath [
+            pkgs.gcc.cc.lib
+          ];
+        };
+      }
+    );
 }


### PR DESCRIPTION
follow up to: https://github.com/sedited/rust-bitcoinkernel/pull/176

### Summary
Adds `nixfmt` and `statix` checks to the CI to enforce formatting and catch linting issues in flake.nix. Also reformats flake.nix with nixfmt.