### PR TITLE
fix(core): replace btck_ScriptVerificationFlags with a public type alias

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- The `verify` function's `flags` parameter now uses `ScriptVerificationFlags` instead of `u32`, making the type explicit in the public API.
+
 ## [0.2.1] 2026-05-20
 
 ### Added

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -21,7 +21,7 @@ pub use block::{
 pub use script::ScriptPubkeyExt;
 pub use transaction::{TransactionExt, TxInExt, TxOutExt, TxOutPointExt, TxidExt};
 
-pub use verify::{verify, PrecomputedTransactionData, ScriptVerifyError};
+pub use verify::{verify, PrecomputedTransactionData, ScriptVerificationFlags, ScriptVerifyError};
 
 pub mod verify_flags {
     pub use super::verify::{

--- a/src/core/verify.rs
+++ b/src/core/verify.rs
@@ -171,37 +171,40 @@ use crate::{
     c_helpers, ffi::sealed::AsPtr, KernelError, ScriptPubkeyExt, TransactionExt, TxOutExt,
 };
 
+/// Bitmask of flags controlling which consensus rules [`verify`] enforces.
+pub type ScriptVerificationFlags = btck_ScriptVerificationFlags;
+
 /// No verification flags.
-pub const VERIFY_NONE: btck_ScriptVerificationFlags = btck_ScriptVerificationFlags_NONE;
+pub const VERIFY_NONE: ScriptVerificationFlags = btck_ScriptVerificationFlags_NONE;
 
 /// Validate Pay-to-Script-Hash (BIP 16).
-pub const VERIFY_P2SH: btck_ScriptVerificationFlags = btck_ScriptVerificationFlags_P2SH;
+pub const VERIFY_P2SH: ScriptVerificationFlags = btck_ScriptVerificationFlags_P2SH;
 
 /// Require strict DER encoding for ECDSA signatures (BIP 66).
-pub const VERIFY_DERSIG: btck_ScriptVerificationFlags = btck_ScriptVerificationFlags_DERSIG;
+pub const VERIFY_DERSIG: ScriptVerificationFlags = btck_ScriptVerificationFlags_DERSIG;
 
 /// Require the dummy element in OP_CHECKMULTISIG to be empty (BIP 147).
-pub const VERIFY_NULLDUMMY: btck_ScriptVerificationFlags = btck_ScriptVerificationFlags_NULLDUMMY;
+pub const VERIFY_NULLDUMMY: ScriptVerificationFlags = btck_ScriptVerificationFlags_NULLDUMMY;
 
 /// Enable OP_CHECKLOCKTIMEVERIFY (BIP 65).
-pub const VERIFY_CHECKLOCKTIMEVERIFY: btck_ScriptVerificationFlags =
+pub const VERIFY_CHECKLOCKTIMEVERIFY: ScriptVerificationFlags =
     btck_ScriptVerificationFlags_CHECKLOCKTIMEVERIFY;
 
 /// Enable OP_CHECKSEQUENCEVERIFY (BIP 112).
-pub const VERIFY_CHECKSEQUENCEVERIFY: btck_ScriptVerificationFlags =
+pub const VERIFY_CHECKSEQUENCEVERIFY: ScriptVerificationFlags =
     btck_ScriptVerificationFlags_CHECKSEQUENCEVERIFY;
 
 /// Validate Segregated Witness programs (BIP 141/143).
-pub const VERIFY_WITNESS: btck_ScriptVerificationFlags = btck_ScriptVerificationFlags_WITNESS;
+pub const VERIFY_WITNESS: ScriptVerificationFlags = btck_ScriptVerificationFlags_WITNESS;
 
 /// Validate Taproot spends (BIP 341/342). Requires spent outputs.
-pub const VERIFY_TAPROOT: btck_ScriptVerificationFlags = btck_ScriptVerificationFlags_TAPROOT;
+pub const VERIFY_TAPROOT: ScriptVerificationFlags = btck_ScriptVerificationFlags_TAPROOT;
 
 /// All consensus rules.
-pub const VERIFY_ALL: btck_ScriptVerificationFlags = btck_ScriptVerificationFlags_ALL;
+pub const VERIFY_ALL: ScriptVerificationFlags = btck_ScriptVerificationFlags_ALL;
 
 /// All consensus rules except Taproot.
-pub const VERIFY_ALL_PRE_TAPROOT: btck_ScriptVerificationFlags = VERIFY_P2SH
+pub const VERIFY_ALL_PRE_TAPROOT: ScriptVerificationFlags = VERIFY_P2SH
     | VERIFY_DERSIG
     | VERIFY_NULLDUMMY
     | VERIFY_CHECKLOCKTIMEVERIFY
@@ -389,7 +392,7 @@ pub fn verify(
     amount: Option<i64>,
     tx_to: &impl TransactionExt,
     input_index: usize,
-    flags: Option<u32>,
+    flags: Option<ScriptVerificationFlags>,
     precomputed_txdata: &PrecomputedTransactionData,
 ) -> Result<(), KernelError> {
     let input_count = tx_to.input_count();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -282,9 +282,10 @@ impl std::error::Error for KernelError {
 
 pub use crate::core::{
     verify, Block, BlockHash, BlockHeader, BlockSpentOutputs, BlockSpentOutputsRef, BlockTreeEntry,
-    Coin, CoinRef, PrecomputedTransactionData, ScriptPubkey, ScriptPubkeyRef, ScriptVerifyError,
-    Transaction, TransactionRef, TransactionSpentOutputs, TransactionSpentOutputsRef, TxIn,
-    TxInRef, TxOut, TxOutPoint, TxOutPointRef, TxOutRef, Txid, TxidRef,
+    Coin, CoinRef, PrecomputedTransactionData, ScriptPubkey, ScriptPubkeyRef,
+    ScriptVerificationFlags, ScriptVerifyError, Transaction, TransactionRef,
+    TransactionSpentOutputs, TransactionSpentOutputsRef, TxIn, TxInRef, TxOut, TxOutPoint,
+    TxOutPointRef, TxOutRef, Txid, TxidRef,
 };
 
 pub use crate::log::{disable_logging, Log, LogCategory, LogLevel, Logger};

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -9,12 +9,11 @@ mod tests {
         prelude::*, verify, Block, BlockHash, BlockHeader, BlockSpentOutputs, BlockTreeEntry,
         BlockValidationStateRef, ChainParams, ChainType, ChainstateManager,
         ChainstateManagerBuilder, Coin, Context, ContextBuilder, KernelError, Log, Logger,
-        PrecomputedTransactionData, ScriptPubkey, ScriptVerifyError, Transaction,
-        TransactionSpentOutputs, TxIn, TxOut, ValidationMode, VERIFY_ALL, VERIFY_ALL_PRE_TAPROOT,
-        VERIFY_CHECKLOCKTIMEVERIFY, VERIFY_CHECKSEQUENCEVERIFY, VERIFY_DERSIG, VERIFY_NONE,
-        VERIFY_NULLDUMMY, VERIFY_P2SH, VERIFY_TAPROOT, VERIFY_WITNESS,
+        PrecomputedTransactionData, ScriptPubkey, ScriptVerificationFlags, ScriptVerifyError,
+        Transaction, TransactionSpentOutputs, TxIn, TxOut, ValidationMode, VERIFY_ALL,
+        VERIFY_ALL_PRE_TAPROOT, VERIFY_CHECKLOCKTIMEVERIFY, VERIFY_CHECKSEQUENCEVERIFY,
+        VERIFY_DERSIG, VERIFY_NONE, VERIFY_NULLDUMMY, VERIFY_P2SH, VERIFY_TAPROOT, VERIFY_WITNESS,
     };
-    use libbitcoinkernel_sys::btck_ScriptVerificationFlags;
     use std::fs::File;
     use std::io::{BufRead, BufReader};
     use std::sync::{Arc, Once};
@@ -865,7 +864,7 @@ mod tests {
         amount: i64,
         input: usize,
         outputs: Vec<TxOut>,
-        flags: btck_ScriptVerificationFlags,
+        flags: ScriptVerificationFlags,
     ) -> Result<(), KernelError> {
         let spent_script_pubkey =
             ScriptPubkey::try_from(hex::decode(spent).unwrap().as_slice()).unwrap();


### PR DESCRIPTION
btck_ScriptVerificationFlags was exposed in the public API via the types on the VERIFY_* constants. Add a ScriptVerificationFlags type alias and update the constants to use it.