### PR TITLE
feat(core): implement Debug for BlockValidationState and related types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Added `Block::check` to perform context-free validation of a block (size, weight, coinbase, transactions, sigops), with optional proof-of-work and merkle-root checks toggled via the `BLOCK_CHECK_BASE` / `_POW` / `_MERKLE` / `_ALL` flags. Returns a `BlockCheckResult` enum carrying the validation state on failure.
+- Implemented `Debug` for `BlockValidationResult`, `BlockValidationStateRef`, `ProcessBlockHeaderresult` and `BlockCheckResult`, enabling inspection via `{:?}` in logs and test output.
 
 ### Changed
 - The `verify` function's `flags` parameter now uses `ScriptVerificationFlags` instead of `u32`, making the type explicit in the public API.

--- a/src/core/block.rs
+++ b/src/core/block.rs
@@ -176,6 +176,7 @@ pub const BLOCK_CHECK_ALL: BlockCheckFlags = btck_BlockCheckFlags_ALL;
 ///
 /// On failure, the [`BlockValidationState`] carries details that can be
 /// inspected via [`BlockValidationStateExt`](crate::notifications::BlockValidationStateExt).
+#[derive(Clone, Debug)]
 pub enum BlockCheckResult {
     /// The block passed the requested context-free checks.
     Valid,
@@ -2346,6 +2347,29 @@ mod tests {
             format!("{block_hash_ref}"),
             "00000000839a8e6886ab5951d76f411475428afc90947ee320161bbf18eb6048"
         );
+    }
+    #[test]
+    fn test_block_check_result_debug() {
+        let valid = BlockCheckResult::Valid;
+        let debug_str = format!("{:?}", valid);
+        assert_eq!(debug_str, "Valid");
+
+        let state = BlockValidationState::new();
+        let invalid = BlockCheckResult::Invalid(state);
+        let debug_str = format!("{:?}", invalid);
+        assert!(debug_str.contains("Invalid"));
+    }
+
+    #[test]
+    fn test_block_check_result_clone() {
+        let valid = BlockCheckResult::Valid;
+        let cloned = valid.clone();
+        assert!(matches!(cloned, BlockCheckResult::Valid));
+
+        let state = BlockValidationState::new();
+        let invalid = BlockCheckResult::Invalid(state);
+        let cloned = invalid.clone();
+        assert!(matches!(cloned, BlockCheckResult::Invalid(_)));
     }
 
     #[test]

--- a/src/notifications/types.rs
+++ b/src/notifications/types.rs
@@ -1,4 +1,7 @@
-use std::marker::PhantomData;
+use std::{
+    fmt::{Debug, Formatter, Result},
+    marker::PhantomData,
+};
 
 use libbitcoinkernel_sys::{
     btck_BlockValidationResult, btck_BlockValidationResult_CACHED_INVALID,
@@ -230,6 +233,15 @@ impl FromMutPtr<btck_BlockValidationState> for BlockValidationState {
 
 impl BlockValidationStateExt for BlockValidationState {}
 
+impl Debug for BlockValidationState {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+        f.debug_struct("BlockValidationState")
+            .field("mode", &self.mode())
+            .field("result", &self.result())
+            .finish()
+    }
+}
+
 impl Clone for BlockValidationState {
     fn clone(&self) -> Self {
         BlockValidationState {
@@ -272,6 +284,15 @@ impl<'a> Copy for BlockValidationStateRef<'a> {}
 impl<'a> Clone for BlockValidationStateRef<'a> {
     fn clone(&self) -> Self {
         *self
+    }
+}
+
+impl<'a> Debug for BlockValidationStateRef<'a> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+        f.debug_struct("BlockValidationStateRef")
+            .field("mode", &self.mode())
+            .field("result", &self.result())
+            .finish()
     }
 }
 
@@ -620,5 +641,26 @@ mod tests {
             let back: BlockValidationResult = btck_result.into();
             assert_eq!(result, back);
         }
+    }
+
+    #[test]
+    fn test_block_validation_state_debug() {
+        let state = BlockValidationState::new();
+        let s = format!("{:?}", state);
+        assert!(s.contains("BlockValidationState"));
+        assert!(s.contains("mode"));
+        assert!(s.contains("result"));
+    }
+
+    #[test]
+    fn test_block_validation_state_ref_debug() {
+        use crate::ffi::sealed::FromPtr;
+        let state = BlockValidationState::new();
+        let state_ref: BlockValidationStateRef<'_> =
+            unsafe { BlockValidationStateRef::from_ptr(state.as_ptr()) };
+        let s = format!("{:?}", state_ref);
+        assert!(s.contains("BlockValidationStateRef"));
+        assert!(s.contains("mode"));
+        assert!(s.contains("result"));
     }
 }

--- a/src/state/chainstate.rs
+++ b/src/state/chainstate.rs
@@ -73,7 +73,7 @@ pub enum ProcessBlockResult {
 /// Result of proceesing a header with the [`ChainstateManager`]
 ///
 /// Indicates whether a block header was processed, or rejected, and whether it is valid.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub enum ProcessBlockHeaderResult {
     /// Header was succssfully processed and added to the block tree
     Success(BlockValidationState),
@@ -816,5 +816,29 @@ mod tests {
         let result = ProcessBlockResult::NewBlock;
         let debug_str = format!("{:?}", result);
         assert_eq!(debug_str, "NewBlock");
+    }
+
+    #[test]
+    fn test_process_block_header_result_debug() {
+        let state = BlockValidationState::new();
+        let success = ProcessBlockHeaderResult::Success(state.clone());
+        let debug_str = format!("{:?}", success);
+        assert!(debug_str.contains("Success"));
+
+        let failed = ProcessBlockHeaderResult::Failed(state);
+        let debug_str = format!("{:?}", failed);
+        assert!(debug_str.contains("Failed"));
+    }
+
+    #[test]
+    fn test_process_block_header_result_clone() {
+        let state = BlockValidationState::new();
+        let success = ProcessBlockHeaderResult::Success(state.clone());
+        let cloned = success.clone();
+        assert!(matches!(cloned, ProcessBlockHeaderResult::Success(_)));
+
+        let failed = ProcessBlockHeaderResult::Failed(state);
+        let cloned = failed.clone();
+        assert!(matches!(cloned, ProcessBlockHeaderResult::Failed(_)));
     }
 }


### PR DESCRIPTION
closes https://github.com/sedited/rust-bitcoinkernel/issues/181

### Changes

Implements `Debug` for `BlockValidationState`, `BlockValidationStateRef`, `ProcessBlockHeaderResult` and `BlockCheckResult`. Also derives `Clone` for `BlockCheckResult` for consistency with `ProcessBlockHeaderResult`.

### Motivation

Allows inspection via `{:?}` in logs.