### PR TITLE
feat: add #[must_use] to BlockCheckResult and ProcessBlockHeaderResult

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Added `Block::check` to perform context-free validation of a block (size, weight, coinbase, transactions, sigops), with optional proof-of-work and merkle-root checks toggled via the `BLOCK_CHECK_BASE` / `_POW` / `_MERKLE` / `_ALL` flags. Returns a `BlockCheckResult` enum carrying the validation state on failure.
+- Added `#[must_use]` to `BlockCheckResult` and `ProcessBlockHeaderResult` to warn when validation results are silently ignored.
 
 ### Changed
 - The `verify` function's `flags` parameter now uses `ScriptVerificationFlags` instead of `u32`, making the type explicit in the public API.

--- a/src/core/block.rs
+++ b/src/core/block.rs
@@ -176,6 +176,7 @@ pub const BLOCK_CHECK_ALL: BlockCheckFlags = btck_BlockCheckFlags_ALL;
 ///
 /// On failure, the [`BlockValidationState`] carries details that can be
 /// inspected via [`BlockValidationStateExt`](crate::notifications::BlockValidationStateExt).
+#[must_use = "check result must be inspected to determine whether the block is valid"]
 pub enum BlockCheckResult {
     /// The block passed the requested context-free checks.
     Valid,

--- a/src/state/chainstate.rs
+++ b/src/state/chainstate.rs
@@ -73,6 +73,7 @@ pub enum ProcessBlockResult {
 /// Result of proceesing a header with the [`ChainstateManager`]
 ///
 /// Indicates whether a block header was processed, or rejected, and whether it is valid.
+#[must_use = "header processing result must be inspected to determine whether processing completed successfully"]
 #[derive(Clone)]
 pub enum ProcessBlockHeaderResult {
     /// Header was succssfully processed and added to the block tree


### PR DESCRIPTION
closes https://github.com/sedited/rust-bitcoinkernel/issues/187

### Changes
Added `#[must_use]` to `BlockCheckResult` and `ProcessBlockHeaderResult` to warn when validation results are silently ignored. 

I have omitted `#[must_use]` from `ProcessBlockResult` as ignoring it is a valid use case. Callers may simply want to submit a block without acting on whether it was new or duplicate.