### PR TITLE
fix(core): use infallible From for ScriptVerifyStatus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `ChainstateManager::process_block_header` now returns `Result<ProcessBlockHeaderResult, KernelError>` instead of `ProcessBlockHeaderResult` directly. `Err` indicates an internal failure; `Ok(ProcessBlockHeaderResult::Invalid(state)` indicates the header failed validation.
 - `ProcessBlockHeaderResult::Success` and `ProcessBlockHeaderResult::Failed` renamed to `ProcessBlockHeaderResult::Valid` and `ProcessBlockHeaderResult::Invalid` respectively. `Valid` no longer carries a `BlockValidationState`.
 
+### Fixed
+- `verify` now uses an infallible conversion for the internal `ScriptVerifyStatus`, since an unrecognized status can only indicate a build-time mismatch between the bindings and the vendored `libbitcoinkernel` subtree rather than a runtime condition.
+
 ## [0.2.1] 2026-05-20
 
 ### Added

--- a/src/core/verify.rs
+++ b/src/core/verify.rs
@@ -425,9 +425,7 @@ pub fn verify(
         )
     };
 
-    let script_status = ScriptVerifyStatus::try_from(status).map_err(|_| {
-        KernelError::Internal(format!("Invalid script verify status: {:?}", status))
-    })?;
+    let script_status = ScriptVerifyStatus::from(status);
 
     if !c_helpers::verification_passed(ret) {
         let err = match script_status {


### PR DESCRIPTION
Status codes are sourced from a vendored subtree build with this crate, so an unknown value indicates a bindings bug, not runtime skew. Panic via `From` rather than returning `KernelError::Internal`.