### PR TITLE
fix(libbitcoinkernel-sys): make `btck_LogCallback` and `btck_WriteBytes` non-nullable 

### DIFF
--- a/libbitcoinkernel-sys/CHANGELOG.md
+++ b/libbitcoinkernel-sys/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `btck_block_header_create` now asserts that the input buffer is non-null and exactly 80 bytes; previously non-null buffer of any length was accepted
 - `btck_transaction_create`, `btck_script_pubkey_create` and `btck_block_create` now assert valid buffer preconditions rather than returning null on invalid input
 - `btck_chainstate_manager_process_block_header` no longer takes a `btck_BlockValidationState` out-parameter; it now returns an owned `*mut btck_BlockValidationState` (null on error)
+- `btck_LogCallback` is no longer wrapped in `Option`; it is a nonnull argument to `btck_logging_connection_create` and passing `None` previously compiled but was UB. Code constructing this callback type directly must now provide a bare `unsafe extern "C" fn(...)` instead of `Some(...)`
 
 ## [0.3.0] - 2026-05-20
 

--- a/libbitcoinkernel-sys/CHANGELOG.md
+++ b/libbitcoinkernel-sys/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `btck_transaction_create`, `btck_script_pubkey_create` and `btck_block_create` now assert valid buffer preconditions rather than returning null on invalid input
 - `btck_chainstate_manager_process_block_header` no longer takes a `btck_BlockValidationState` out-parameter; it now returns an owned `*mut btck_BlockValidationState` (null on error)
 - `btck_LogCallback` is no longer wrapped in `Option`; it is a nonnull argument to `btck_logging_connection_create` and passing `None` previously compiled but was UB. Code constructing this callback type directly must now provide a bare `unsafe extern "C" fn(...)` instead of `Some(...)`
+- `btck_WriteBytes` is no longer wrapped in `Option`; it is a nonnull argument to `btck_transaction_to_bytes`, `btck_script_pubkey_to_bytes` and `btck_block_to_bytes` and passing `None` previously compiled but was UB. Code constructing this callback type directly must now provide a bare `unsafe extern "C" fn(...)` instead of `Some(...)`
 
 ## [0.3.0] - 2026-05-20
 

--- a/libbitcoinkernel-sys/src/lib.rs
+++ b/libbitcoinkernel-sys/src/lib.rs
@@ -316,7 +316,7 @@ pub type btck_ValidationInterfacePoWValidBlock = Option<
 >;
 
 pub type btck_WriteBytes =
-    Option<unsafe extern "C" fn(bytes: *const c_void, size: usize, userdata: *mut c_void) -> c_int>;
+    unsafe extern "C" fn(bytes: *const c_void, size: usize, userdata: *mut c_void) -> c_int;
 
 // These structs are passed by value across the FFI boundary - alphabetical order
 // Field order must match C exactly - sizes verified by const assertions below

--- a/libbitcoinkernel-sys/src/lib.rs
+++ b/libbitcoinkernel-sys/src/lib.rs
@@ -231,9 +231,8 @@ pub struct btck_Txid {
 
 pub type btck_DestroyCallback = Option<unsafe extern "C" fn(user_data: *mut c_void)>;
 
-pub type btck_LogCallback = Option<
-    unsafe extern "C" fn(user_data: *mut c_void, message: *const c_char, message_len: usize),
->;
+pub type btck_LogCallback =
+    unsafe extern "C" fn(user_data: *mut c_void, message: *const c_char, message_len: usize);
 
 pub type btck_NotifyBlockTip = Option<
     unsafe extern "C" fn(

--- a/src/core/block.rs
+++ b/src/core/block.rs
@@ -956,7 +956,7 @@ impl Block {
     /// ```
     pub fn consensus_encode(&self) -> Result<Vec<u8>, KernelError> {
         c_serialize(|callback, user_data| unsafe {
-            btck_block_to_bytes(self.inner, Some(callback), user_data)
+            btck_block_to_bytes(self.inner, callback, user_data)
         })
     }
 

--- a/src/core/script.rs
+++ b/src/core/script.rs
@@ -83,7 +83,7 @@ pub trait ScriptPubkeyExt: AsPtr<btck_ScriptPubkey> {
     /// ```
     fn to_bytes(&self) -> Vec<u8> {
         c_serialize(|callback, user_data| unsafe {
-            btck_script_pubkey_to_bytes(self.as_ptr(), Some(callback), user_data)
+            btck_script_pubkey_to_bytes(self.as_ptr(), callback, user_data)
         })
         .expect("Script pubkey to_bytes should never fail")
     }
@@ -127,7 +127,7 @@ pub trait ScriptPubkeyExt: AsPtr<btck_ScriptPubkey> {
         let ret = unsafe {
             btck_script_pubkey_to_bytes(
                 self.as_ptr(),
-                Some(writer),
+                writer,
                 &mut out as *mut BytesOut as *mut c_void,
             )
         };

--- a/src/core/transaction.rs
+++ b/src/core/transaction.rs
@@ -341,7 +341,7 @@ pub trait TransactionExt: AsPtr<btck_Transaction> {
     /// ```
     fn consensus_encode(&self) -> Result<Vec<u8>, KernelError> {
         c_serialize(|callback, user_data| unsafe {
-            btck_transaction_to_bytes(self.as_ptr(), Some(callback), user_data)
+            btck_transaction_to_bytes(self.as_ptr(), callback, user_data)
         })
     }
 

--- a/src/log/logging.rs
+++ b/src/log/logging.rs
@@ -115,7 +115,7 @@ impl Logger {
 
         let inner = unsafe {
             btck_logging_connection_create(
-                Some(log_callback::<T>),
+                log_callback::<T>,
                 log_ptr as *mut c_void,
                 Some(destroy_log_callback::<T>),
             )


### PR DESCRIPTION
## Summary

Both types are marked `BITCOINKERNEL_ARG_NONNULL` in the C Header at every call site, but were bound as `Option<unsafe extern "C" fn(...)` letting callers pass None, which lowers to a null pointer and is UB in C.

This PR drops the `Option` wrapper so null is representable at the type level.

## Changes

- `btck_LogCallback`: bare `unsafe extern "C" fn(...)`. Updated `btck_logging_connection_create` call site to pass `log_callback::<T>` instead of `Some(log_callback::<T>)`.
- `btck_WriteBytes`: same treatment. Used as the nonnull `writer` arg in `btck_transaction_to_bytes`, `btck_script_pubkey_to_bytes`, `btck_block_to_bytes`. The `c_serialize` helper and its call sites already pass the callback unwrapped, so no further changes needed.

## Why

Neither type ever had a valid "null" use case.