### PR TITLE
feat(build): skip building when prebuilt bitcoinkernel is present.

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,17 @@ dependencies. Once setup, run:
 cargo b
 ```
 
+### Using a pre-built `libbitcoinkernel`
+
+If you have a pre-built `libbitcoinkernel.a`, you can skip the CMake build
+step entirely by pointing `LIBBITCOINKERNEL_LIB_DIR` to the directory
+containing it:
+
+```bash
+export LIBBITCOINKERNEL_LIB_DIR=/path/to/lib
+cargo build
+```
+
 ## MSRV (Minimum Supported Rust Version)
 
 The minimum supported Rust version is 1.71. Users on rustc older than

--- a/libbitcoinkernel-sys/CHANGELOG.md
+++ b/libbitcoinkernel-sys/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- New `LIBBITCOINKERNEL_LIB_DIR` option on build.rs that skips building process in order of a prebuilt libbitcoinkernel.
 - New `btck_TxValidationState` opaque type for holding transaction validation state
 - New `btck_TxValidationResult` type with named constants for all transaction validation result variants
 - New `btck_tx_validation_state_create`, `btck_tx_validation_state_get_validation_mode`, `btck_tx_validation_state_get_tx_validation_result` and `btck_tx_validation_state_destroy` for managing and inspecting transaction validation state

--- a/libbitcoinkernel-sys/build.rs
+++ b/libbitcoinkernel-sys/build.rs
@@ -3,76 +3,86 @@ use std::path::Path;
 use std::process::Command;
 
 fn main() {
-    let bitcoin_dir = Path::new("bitcoin");
-    let out_dir = env::var("OUT_DIR").unwrap();
-    let build_dir = Path::new(&out_dir).join("bitcoin");
-    let install_dir = Path::new(&out_dir).join("install");
+    // When LIBBITCOINKERNEL_LIB_DIR is set, skip the CMake build and link
+    // against the pre-built library directly (same pattern as openssl-sys).
+    println!("cargo:rerun-if-env-changed=LIBBITCOINKERNEL_LIB_DIR");
 
-    println!("{} {}", bitcoin_dir.display(), build_dir.display());
-
-    // Iterate through all files in the Bitcoin Core submodule directory
-    println!("cargo:rerun-if-changed={}", bitcoin_dir.display());
-
-    let build_config = "RelWithDebInfo";
-
-    Command::new("cmake")
-        .arg("-B")
-        .arg(&build_dir)
-        .arg("-S")
-        .arg(bitcoin_dir)
-        .arg(format!("-DCMAKE_BUILD_TYPE={build_config}"))
-        .arg("-DBUILD_KERNEL_LIB=ON")
-        .arg("-DBUILD_TESTS=OFF")
-        .arg("-DBUILD_BENCH=OFF")
-        .arg("-DBUILD_KERNEL_TEST=OFF")
-        .arg("-DBUILD_TX=OFF")
-        .arg("-DBUILD_WALLET_TOOL=OFF")
-        .arg("-DENABLE_WALLET=OFF")
-        .arg("-DENABLE_EXTERNAL_SIGNER=OFF")
-        .arg("-DBUILD_UTIL=OFF")
-        .arg("-DBUILD_BITCOIN_BIN=OFF")
-        .arg("-DBUILD_DAEMON=OFF")
-        .arg("-DBUILD_UTIL_CHAINSTATE=OFF")
-        .arg("-DBUILD_CLI=OFF")
-        .arg("-DBUILD_FUZZ_BINARY=OFF")
-        .arg("-DBUILD_SHARED_LIBS=OFF")
-        .arg("-DCMAKE_INSTALL_LIBDIR=lib")
-        .arg("-DENABLE_IPC=OFF")
-        .arg(format!("-DCMAKE_INSTALL_PREFIX={}", install_dir.display()))
-        .status()
-        .expect("cmake should be installed and available in PATH");
-
-    let num_jobs = env::var("NUM_JOBS")
-        .ok()
-        .and_then(|v| v.parse::<u32>().ok())
-        .unwrap_or(1); // Default to 1 if not set
-
-    Command::new("cmake")
-        .arg("--build")
-        .arg(&build_dir)
-        .arg("--config")
-        .arg(build_config)
-        .arg(format!("--parallel={num_jobs}"))
-        .status()
-        .unwrap();
-
-    Command::new("cmake")
-        .arg("--install")
-        .arg(&build_dir)
-        .arg("--config")
-        .arg(build_config)
-        .status()
-        .unwrap();
-
-    // Check if the build system used a multi-config generator
-    let lib_dir = if install_dir.join("lib").join(build_config).exists() {
-        install_dir.join("lib").join(build_config)
+    if let Ok(lib_dir) = env::var("LIBBITCOINKERNEL_LIB_DIR") {
+        println!("cargo:rustc-link-search=native={lib_dir}");
+        println!("cargo:rustc-link-lib=static=bitcoinkernel");
     } else {
-        install_dir.join("lib")
-    };
-    println!("cargo:rustc-link-search=native={}", lib_dir.display());
+        let bitcoin_dir = Path::new("bitcoin");
+        let out_dir = env::var("OUT_DIR").unwrap();
+        let build_dir = Path::new(&out_dir).join("bitcoin");
+        let install_dir = Path::new(&out_dir).join("install");
 
-    println!("cargo:rustc-link-lib=static=bitcoinkernel");
+        println!("{} {}", bitcoin_dir.display(), build_dir.display());
+
+        // Iterate through all files in the Bitcoin Core submodule directory
+        println!("cargo:rerun-if-changed={}", bitcoin_dir.display());
+
+        let build_config = "RelWithDebInfo";
+
+        Command::new("cmake")
+            .arg("-B")
+            .arg(&build_dir)
+            .arg("-S")
+            .arg(bitcoin_dir)
+            .arg(format!("-DCMAKE_BUILD_TYPE={build_config}"))
+            .arg("-DBUILD_KERNEL_LIB=ON")
+            .arg("-DBUILD_TESTS=OFF")
+            .arg("-DBUILD_BENCH=OFF")
+            .arg("-DBUILD_KERNEL_TEST=OFF")
+            .arg("-DBUILD_TX=OFF")
+            .arg("-DBUILD_WALLET_TOOL=OFF")
+            .arg("-DENABLE_WALLET=OFF")
+            .arg("-DENABLE_EXTERNAL_SIGNER=OFF")
+            .arg("-DBUILD_UTIL=OFF")
+            .arg("-DBUILD_BITCOIN_BIN=OFF")
+            .arg("-DBUILD_DAEMON=OFF")
+            .arg("-DBUILD_UTIL_CHAINSTATE=OFF")
+            .arg("-DBUILD_CLI=OFF")
+            .arg("-DBUILD_FUZZ_BINARY=OFF")
+            .arg("-DBUILD_SHARED_LIBS=OFF")
+            .arg("-DCMAKE_INSTALL_LIBDIR=lib")
+            .arg("-DENABLE_IPC=OFF")
+            .arg(format!("-DCMAKE_INSTALL_PREFIX={}", install_dir.display()))
+            .status()
+            .expect("cmake should be installed and available in PATH");
+
+        let num_jobs = env::var("NUM_JOBS")
+            .ok()
+            .and_then(|v| v.parse::<u32>().ok())
+            .unwrap_or(1); // Default to 1 if not set
+
+        Command::new("cmake")
+            .arg("--build")
+            .arg(&build_dir)
+            .arg("--config")
+            .arg(build_config)
+            .arg(format!("--parallel={num_jobs}"))
+            .status()
+            .unwrap();
+
+        Command::new("cmake")
+            .arg("--install")
+            .arg(&build_dir)
+            .arg("--config")
+            .arg(build_config)
+            .status()
+            .unwrap();
+
+        // Check if the build system used a multi-config generator
+        let lib_dir = if install_dir.join("lib").join(build_config).exists() {
+            install_dir.join("lib").join(build_config)
+        } else {
+            install_dir.join("lib")
+        };
+
+        println!("cargo:rustc-link-search=native={}", lib_dir.display());
+
+        println!("cargo:rustc-link-lib=static=bitcoinkernel");
+    }
 
     let compiler = cc::Build::new().get_compiler();
     let target_os = std::env::var("CARGO_CFG_TARGET_OS").unwrap();


### PR DESCRIPTION
When LIBBITCOINKERNEL_LIB_DIR is set, skip the entire CMake configure/build/install and link against the pre-built library directly. This follows the same pattern as openssl-sys with OPENSSL_LIB_DIR and helpa with building corner cases.

makes more sense after #158 