### PR TITLE
refactor(libbitcoinkernel-sys): restructure `build.rs` around TargetConfig

### DIFF
--- a/libbitcoinkernel-sys/build.rs
+++ b/libbitcoinkernel-sys/build.rs
@@ -1,187 +1,328 @@
 use std::env;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::process::Command;
 
-fn main() {
-    let target_os = env::var("CARGO_CFG_TARGET_OS").unwrap();
-    let is_android = target_os == "android";
+const BUILD_CONFIG: &str = "RelWithDebInfo";
+const MIN_ANDROID_API: u32 = 24;
+const BITCOIN_SRC_DIR: &str = "bitcoin";
 
-    let ndk = if is_android {
-        Some(
-            env::var("ANDROID_NDK_HOME")
-                .expect("Android target detected but ANDROID_NDK_HOME is not set"),
-        )
+const BASE_CMAKE_FLAGS: &[&str] = &[
+    "-DBUILD_KERNEL_LIB=ON",
+    "-DBUILD_TESTS=OFF",
+    "-DBUILD_BENCH=OFF",
+    "-DBUILD_KERNEL_TEST=OFF",
+    "-DBUILD_TX=OFF",
+    "-DBUILD_WALLET_TOOL=OFF",
+    "-DENABLE_WALLET=OFF",
+    "-DENABLE_EXTERNAL_SIGNER=OFF",
+    "-DBUILD_UTIL=OFF",
+    "-DBUILD_BITCOIN_BIN=OFF",
+    "-DBUILD_DAEMON=OFF",
+    "-DBUILD_UTIL_CHAINSTATE=OFF",
+    "-DBUILD_CLI=OFF",
+    "-DBUILD_FUZZ_BINARY=OFF",
+    "-DBUILD_SHARED_LIBS=OFF",
+    "-DCMAKE_INSTALL_LIBDIR=lib",
+    "-DENABLE_IPC=OFF",
+];
+fn main() {
+    let target = target_config();
+
+    for var in target.rerun_env {
+        println!("cargo:rerun-if-env-changed={var}");
+    }
+
+    let lib_dir = build_kernel(&target.cmake_args);
+
+    println!("cargo:rustc-link-search=native={}", lib_dir.display());
+    println!("cargo:rustc-link-lib=static=bitcoinkernel");
+
+    for directive in &target.link_directives {
+        println!("cargo:{directive}");
+    }
+}
+
+fn build_kernel(extra_cmake_args: &[String]) -> PathBuf {
+    let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
+    let cmake = Cmake::new(BITCOIN_SRC_DIR, &out_dir);
+
+    // Rebuild whenever anything in the Bitcoin Core submodule changes.
+    println!("cargo:rerun-if-changed={BITCOIN_SRC_DIR}");
+
+    cmake.configure(extra_cmake_args);
+    cmake.build();
+    cmake.install();
+
+    cmake.lib_dir()
+}
+
+// Everything that varies by platform, resolved once up front.
+#[derive(Default)]
+struct TargetConfig {
+    // Extra cmake flags needed to cross-compile for this target.
+    cmake_args: Vec<String>,
+    // Emitted verbatim as `cargo:{directive}`.
+    link_directives: Vec<String>,
+    // Variables that should force a rebuild when they change.
+    rerun_env: &'static [&'static str],
+}
+
+fn target_config() -> TargetConfig {
+    match &*env::var("CARGO_CFG_TARGET_OS").unwrap() {
+        "windows" => TargetConfig {
+            link_directives: vec![
+                "rustc-link-lib=bcrypt".into(),
+                "rustc-link-lib=shell32".into(),
+            ],
+            ..Default::default()
+        },
+
+        "macos" | "ios" | "tvos" | "watchos" | "visionos" => TargetConfig {
+            link_directives: cxx_runtime("c++"),
+            ..Default::default()
+        },
+
+        "android" => Android::from_env().config(),
+
+        "linux" | "freebsd" | "openbsd" | "netbsd" | "dragonfly" | "illumos" | "solaris" => {
+            TargetConfig {
+                link_directives: cxx_runtime("stdc++"),
+                ..Default::default()
+            }
+        }
+
+        other => panic!(
+            "unsupported target OS: {other}. If the generic libstdc++ handling \
+            works there, add it to the linux/BSD arm in build.rs."
+        ),
+    }
+}
+
+fn cxx_runtime(clang_lib: &str) -> Vec<String> {
+    let compiler = cc::Build::new().get_compiler();
+
+    let lib = if compiler.is_like_clang() {
+        clang_lib
+    } else if compiler.is_like_gnu() {
+        "stdc++"
     } else {
-        None
+        return Vec::new();
     };
 
-    let bitcoin_dir = Path::new("bitcoin");
-    let out_dir = env::var("OUT_DIR").unwrap();
-    let build_dir = Path::new(&out_dir).join("bitcoin");
-    let install_dir = Path::new(&out_dir).join("install");
+    vec![format!("rustc-link-lib=dylib={lib}")]
+}
 
-    println!("{} {}", bitcoin_dir.display(), build_dir.display());
+#[derive(PartialEq, Eq, Clone, Copy)]
+enum Abi {
+    Arm64,
+    ArmV7,
+    X86_64,
+}
 
-    // Iterate through all files in the Bitcoin Core submodule directory
-    println!("cargo:rerun-if-changed={}", bitcoin_dir.display());
-
-    let build_config = "RelWithDebInfo";
-
-    let mut cmake_configure = Command::new("cmake");
-    cmake_configure
-        .arg("-B")
-        .arg(&build_dir)
-        .arg("-S")
-        .arg(bitcoin_dir)
-        .arg(format!("-DCMAKE_BUILD_TYPE={build_config}"))
-        .arg("-DBUILD_KERNEL_LIB=ON")
-        .arg("-DBUILD_TESTS=OFF")
-        .arg("-DBUILD_BENCH=OFF")
-        .arg("-DBUILD_KERNEL_TEST=OFF")
-        .arg("-DBUILD_TX=OFF")
-        .arg("-DBUILD_WALLET_TOOL=OFF")
-        .arg("-DENABLE_WALLET=OFF")
-        .arg("-DENABLE_EXTERNAL_SIGNER=OFF")
-        .arg("-DBUILD_UTIL=OFF")
-        .arg("-DBUILD_BITCOIN_BIN=OFF")
-        .arg("-DBUILD_DAEMON=OFF")
-        .arg("-DBUILD_UTIL_CHAINSTATE=OFF")
-        .arg("-DBUILD_CLI=OFF")
-        .arg("-DBUILD_FUZZ_BINARY=OFF")
-        .arg("-DBUILD_SHARED_LIBS=OFF")
-        .arg("-DCMAKE_INSTALL_LIBDIR=lib")
-        .arg("-DENABLE_IPC=OFF")
-        .arg(format!("-DCMAKE_INSTALL_PREFIX={}", install_dir.display()));
-
-    if is_android {
-        let ndk = ndk.as_deref().unwrap();
-        let toolchain_file = format!("{ndk}/build/cmake/android.toolchain.cmake");
-
-        // Rust target triple -> NDK ABI name.
-        let abi = match env::var("TARGET").unwrap() {
-            t if t.contains("aarch64") => "arm64-v8a",
-            t if t.contains("armv7") => "armeabi-v7a",
-            t if t.contains("x86_64") => "x86_64",
+impl Abi {
+    fn from_env() -> Self {
+        match &*env::var("TARGET").unwrap() {
+            t if t.contains("aarch64") => Self::Arm64,
+            t if t.contains("armv7") => Self::ArmV7,
+            t if t.contains("x86_64") => Self::X86_64,
             target => panic!("Unsupported Android ABI: {target}"),
-        };
+        }
+    }
 
-        // API level 24+ is required because Bitcoin Core uses getifaddrs
+    // Value for `-DANDROID_ABI`.
+    fn cmake_name(self) -> &'static str {
+        match self {
+            Self::Arm64 => "arm64-v8a",
+            Self::ArmV7 => "armeabi-v7a",
+            Self::X86_64 => "x86_64",
+        }
+    }
+
+    // NDK sysroot lib directory triple. Differs from the Rust triple for
+    // armv7: Rust says `armv7-linux-androideabi`, the NDK says
+    // `arm-linux-androideabi`.
+    fn ndk_triple(self) -> &'static str {
+        match self {
+            Self::Arm64 => "aarch64-linux-android",
+            Self::ArmV7 => "arm-linux-androideabi",
+            Self::X86_64 => "x86_64-linux-android",
+        }
+    }
+}
+
+struct Android {
+    ndk: PathBuf,
+    abi: Abi,
+    api_level: u32,
+}
+
+impl Android {
+    fn from_env() -> Self {
+        let ndk = env::var("ANDROID_NDK_HOME")
+            .map(PathBuf::from)
+            .expect("Android target detected but ANDROID_NDK_HOME is not set");
+
+        // API level 24+ is required because Bitcoin Core uses getifaddrs,
         // which was introduced in Android API 24 (Nougat).
-        //
-        // This can be overridden to a higher level by setting ANDROID_API_LEVEL.
         let api_level = match env::var("ANDROID_API_LEVEL") {
             Ok(level) => {
                 let n: u32 = level.parse().expect("ANDROID_API_LEVEL must be a number");
-                assert!(n >= 24, "ANDROID_API_LEVEL must be 24+");
-                level
+                assert!(
+                    n >= MIN_ANDROID_API,
+                    "ANDROID_API_LEVEL must be {MIN_ANDROID_API}+"
+                );
+                n
             }
-            _ => "24".to_string(),
+            Err(_) => MIN_ANDROID_API,
         };
 
-        cmake_configure
-            .arg(format!("-DCMAKE_TOOLCHAIN_FILE={toolchain_file}"))
-            .arg(format!("-DANDROID_ABI={abi}"))
-            .arg(format!("-DANDROID_PLATFORM=android-{api_level}"))
-            .arg("-DCMAKE_SYSTEM_NAME=Android")
-            .arg(format!("-DCMAKE_ANDROID_NDK={ndk}"))
-            // The Android NDK toolchain sets CMAKE_FIND_ROOT_PATH_MODE_PACKAGE
-            // to ONLY, which prevents cmake from finding host packages via
-            // CMAKE_PREFIX_PATH. Override it so Boost headers can be located.
-            .arg("-DCMAKE_FIND_ROOT_PATH_MODE_PACKAGE=BOTH");
+        Self {
+            ndk,
+            abi: Abi::from_env(),
+            api_level,
+        }
     }
 
-    cmake_configure
-        .status()
-        .expect("cmake should be installed and available in PATH");
+    fn toolchain_file(&self) -> PathBuf {
+        self.ndk
+            .join("build")
+            .join("cmake")
+            .join("android.toolchain.cmake")
+    }
 
-    let num_jobs = env::var("NUM_JOBS")
-        .ok()
-        .and_then(|v| v.parse::<u32>().ok())
-        .unwrap_or(1); // Default to 1 if not set
-
-    Command::new("cmake")
-        .arg("--build")
-        .arg(&build_dir)
-        .arg("--config")
-        .arg(build_config)
-        .arg(format!("--parallel={num_jobs}"))
-        .status()
-        .unwrap();
-
-    Command::new("cmake")
-        .arg("--install")
-        .arg(&build_dir)
-        .arg("--config")
-        .arg(build_config)
-        .status()
-        .unwrap();
-
-    // Check if the build system used a multi-config generator
-    let lib_dir = if install_dir.join("lib").join(build_config).exists() {
-        install_dir.join("lib").join(build_config)
-    } else {
-        install_dir.join("lib")
-    };
-
-    println!("cargo:rustc-link-search=native={}", lib_dir.display());
-
-    println!("cargo:rustc-link-lib=static=bitcoinkernel");
-
-    let compiler = cc::Build::new().get_compiler();
-
-    if target_os == "windows" {
-        println!("cargo:rustc-link-lib=bcrypt");
-        println!("cargo:rustc-link-lib=shell32");
-    } else if is_android {
-        // Without these, changing either variable between builds won't trigger a rebuild,
-        // so we could silently end up with a stale binary built against the wrong NDK or API level.
-        println!("cargo:rerun-if-env-changed=ANDROID_NDK_HOME");
-        println!("cargo:rerun-if-env-changed=ANDROID_API_LEVEL");
-        // Android NDK ships libc++_static.a and libc++abi.a in the
-        // per-architecture sysroot directory (not the API-level subdirectory).
-        let ndk = ndk.as_deref().unwrap();
-
-        // Rust target triple -> NDK sysroot lib directory triple.
-        // armv7 differs: Rust says `armv7-linux-androideabi`, NDK says `arm-linux-androideabi`.
-        let ndk_triple = env::var("TARGET")
-            .map(|target| {
-                if target.starts_with("armv7") {
-                    "arm-linux-androideabi".into()
-                } else {
-                    target
-                }
-            })
-            .unwrap();
-
-        let host_tag = match std::env::consts::OS {
+    fn sysroot_lib_dir(&self) -> PathBuf {
+        let host_tag = match env::consts::OS {
             "macos" => "darwin-x86_64",
             "linux" => "linux-x86_64",
             os => panic!("unsupported build host for Android cross-compilation: {os}"),
         };
 
-        let ndk_lib_dir =
-            format!("{ndk}/toolchains/llvm/prebuilt/{host_tag}/sysroot/usr/lib/{ndk_triple}");
-        println!("cargo:rustc-link-search=native={ndk_lib_dir}");
-        println!("cargo:rustc-link-lib=static=c++_static");
-        println!("cargo:rustc-link-lib=static=c++abi");
-
-        // The pre-compiled libcompiler_builtins for armv7-linux-androideabi
-        // ships ARM EABI helper symbols tagged with @@LIBC_N (e.g.
-        // __aeabi_memcpy@@LIBC_N).  When lld links a shared library or
-        // executable it errors because the LIBC_N version node is not
-        // defined in any version script.  --exclude-libs,ALL marks every
-        // symbol pulled from static archives as local, which suppresses
-        // the version-node error.
-        if ndk_triple == "arm-linux-androideabi" {
-            println!("cargo:rustc-link-arg=-Wl,--exclude-libs,ALL");
-        }
-    } else if compiler.is_like_clang() {
-        if target_os == "macos" {
-            println!("cargo:rustc-link-lib=dylib=c++");
-        } else {
-            println!("cargo:rustc-link-lib=dylib=stdc++");
-        }
-    } else if compiler.is_like_gnu() {
-        println!("cargo:rustc-link-lib=dylib=stdc++");
+        self.ndk
+            .join("toolchains/llvm/prebuilt")
+            .join(host_tag)
+            .join("sysroot/usr/lib")
+            .join(self.abi.ndk_triple())
     }
+
+    fn config(&self) -> TargetConfig {
+        let cmake_args = vec![
+            format!("-DCMAKE_TOOLCHAIN_FILE={}", self.toolchain_file().display()),
+            format!("-DANDROID_ABI={}", self.abi.cmake_name()),
+            format!("-DANDROID_PLATFORM=android-{}", self.api_level),
+            "-DCMAKE_SYSTEM_NAME=Android".into(),
+            format!("-DCMAKE_ANDROID_NDK={}", self.ndk.display()),
+            // The NDK toolchain sets CMAKE_FIND_ROOT_PATH_MODE_PACKAGE to ONLY,
+            // which prevents cmake from finding host packages via
+            // CMAKE_PREFIX_PATH. Relax it for headers so Boost can be located.
+            "-DCMAKE_FIND_ROOT_PATH_MODE_PACKAGE=BOTH".into(),
+        ];
+
+        // The NDK ships libc++_static.a and libc++abi.a in the per-architecture
+        // sysroot directory, not the API-level subdirectory.
+        let mut link_directives = vec![
+            format!(
+                "rustc-link-search=native={}",
+                self.sysroot_lib_dir().display()
+            ),
+            "rustc-link-lib=static=c++_static".into(),
+            "rustc-link-lib=static=c++abi".into(),
+        ];
+
+        // The pre-compiled libcompiler_builtins for armv7-linux-androideabi ships
+        // ARM EABI helper symbols tagged with @@LIBC_N (e.g. __aeabi_memcpy@@LIBC_N).
+        // lld errors when linking a shared library or executable because the LIBC_N
+        // version node is not defined in any version script. --exclude-libs,ALL
+        // marks every symbol pulled from static archives as local, suppressing it.
+        if self.abi == Abi::ArmV7 {
+            link_directives.push("rustc-link-arg=-Wl,--exclude-libs,ALL".into());
+        }
+
+        TargetConfig {
+            cmake_args,
+            link_directives,
+            rerun_env: &["ANDROID_NDK_HOME", "ANDROID_API_LEVEL"],
+        }
+    }
+}
+
+struct Cmake {
+    source_dir: PathBuf,
+    build_dir: PathBuf,
+    install_dir: PathBuf,
+}
+
+impl Cmake {
+    fn new(source_dir: impl Into<PathBuf>, out_dir: &Path) -> Self {
+        Self {
+            source_dir: source_dir.into(),
+            build_dir: out_dir.join("bitcoin"),
+            install_dir: out_dir.join("install"),
+        }
+    }
+
+    fn configure(&self, extra_args: &[String]) {
+        let mut flags = vec![format!("-DCMAKE_BUILD_TYPE={BUILD_CONFIG}")];
+        flags.extend(BASE_CMAKE_FLAGS.iter().map(|s| s.to_string()));
+        flags.extend_from_slice(extra_args);
+        flags.push(format!(
+            "-DCMAKE_INSTALL_PREFIX={}",
+            self.install_dir.display()
+        ));
+        run(
+            Command::new("cmake")
+                .arg("-B")
+                .arg(&self.build_dir)
+                .arg("-S")
+                .arg(&self.source_dir)
+                .args(flags),
+            "cmake configure",
+        );
+    }
+
+    fn build(&self) {
+        let num_jobs = env::var("NUM_JOBS")
+            .ok()
+            .and_then(|v| v.parse::<u32>().ok())
+            .unwrap_or(1); // Default to 1 if not set
+
+        run(
+            Command::new("cmake")
+                .arg("--build")
+                .arg(&self.build_dir)
+                .arg("--config")
+                .arg(BUILD_CONFIG)
+                .arg(format!("--parallel={num_jobs}")),
+            "cmake build",
+        );
+    }
+
+    fn install(&self) {
+        run(
+            Command::new("cmake")
+                .arg("--install")
+                .arg(&self.build_dir)
+                .arg("--config")
+                .arg(BUILD_CONFIG),
+            "cmake install",
+        );
+    }
+
+    // Multi-config generators (MSVC, Xcode) nest the config name under `lib/`.
+    fn lib_dir(&self) -> PathBuf {
+        let multi_config = self.install_dir.join("lib").join(BUILD_CONFIG);
+
+        if multi_config.exists() {
+            multi_config
+        } else {
+            self.install_dir.join("lib")
+        }
+    }
+}
+
+fn run(cmd: &mut Command, what: &str) {
+    let status = cmd
+        .status()
+        .unwrap_or_else(|e| panic!("failed to spawn {what}: {e}"));
+
+    assert!(status.success(), "{what} failed with {status}");
 }

--- a/libbitcoinkernel-sys/build.rs
+++ b/libbitcoinkernel-sys/build.rs
@@ -283,7 +283,11 @@ impl Cmake {
         let num_jobs = env::var("NUM_JOBS")
             .ok()
             .and_then(|v| v.parse::<u32>().ok())
-            .unwrap_or(1); // Default to 1 if not set
+            .unwrap_or_else(|| {
+                std::thread::available_parallelism()
+                    .map(|n| n.get() as u32)
+                    .unwrap_or(1) // Default to 1 if not set
+            });
 
         run(
             Command::new("cmake")

--- a/libbitcoinkernel-sys/build.rs
+++ b/libbitcoinkernel-sys/build.rs
@@ -121,11 +121,11 @@ enum Abi {
 
 impl Abi {
     fn from_env() -> Self {
-        match &*env::var("TARGET").unwrap() {
-            t if t.contains("aarch64") => Self::Arm64,
-            t if t.contains("armv7") => Self::ArmV7,
-            t if t.contains("x86_64") => Self::X86_64,
-            target => panic!("Unsupported Android ABI: {target}"),
+        match &*env::var("CARGO_CFG_TARGET_ARCH").unwrap() {
+            "aarch64" => Self::Arm64,
+            "arm" => Self::ArmV7,
+            "x86_64" => Self::X86_64,
+            arch => panic!("Unsupported Android ABI: {arch}"),
         }
     }
 


### PR DESCRIPTION
## Summary

Replace the inline per-platform conditionals with a TargetConfig struct returned from target_config(), where each target-OS arm supplies its own cmake args, link directives, and rerun-if-env-changed vars. Android handling moves into an Android struct plus an Abi enum that owns the ANDROID_ABI value and the NDK sysroot triple. Wrap the cmake configure, build and install invocations in a Cmake struct, and hoist the fixed flags into BASE_CMAKE_FLAGS.

**Two small follow-ups on top:**

- Android ABI detection now uses `CARGO_CFG_TARGET_ARCH` rather than the previous mechanism.
- Job count falls back to `available_parallelism` when not otherwise specified.

### Why this matters

The refactor aims to separate and clarify build behavior for different targets.


cc: @jaoleal 