### PR TITLE
fix(state): pass the block hash pointer to get_block_tree_entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - `verify` now uses an infallible conversion for the internal `ScriptVerifyStatus`, since an unrecognized status can only indicate a build-time mismatch between the bindings and the vendored `libbitcoinkernel` subtree rather than a runtime condition.
+- `ChainstateManager::get_block_tree_entry` now resolves the requested block instead of returning `None` for every input. It passed the address of the `BlockHash` wrapper to the kernel rather than the block hash handle the wrapper owns, so no lookup ever matched an entry in the block tree.
 
 ## [0.2.1] 2026-05-20
 

--- a/src/state/chainstate.rs
+++ b/src/state/chainstate.rs
@@ -28,7 +28,7 @@
 use std::ffi::CString;
 
 use libbitcoinkernel_sys::{
-    btck_BlockHash, btck_ChainstateManager, btck_ChainstateManagerOptions, btck_block_read,
+    btck_ChainstateManager, btck_ChainstateManagerOptions, btck_block_read,
     btck_block_spent_outputs_read, btck_chainstate_manager_create, btck_chainstate_manager_destroy,
     btck_chainstate_manager_get_active_chain, btck_chainstate_manager_get_best_entry,
     btck_chainstate_manager_get_block_tree_entry_by_hash, btck_chainstate_manager_import_blocks,
@@ -461,10 +461,7 @@ impl ChainstateManager {
     /// [`ChainstateManager`] and becomes invalid when the manager is dropped.
     pub fn get_block_tree_entry(&self, block_hash: &BlockHash) -> Option<BlockTreeEntry<'_>> {
         let ptr = unsafe {
-            btck_chainstate_manager_get_block_tree_entry_by_hash(
-                self.inner,
-                block_hash as *const _ as *const btck_BlockHash,
-            )
+            btck_chainstate_manager_get_block_tree_entry_by_hash(self.inner, block_hash.as_ptr())
         };
         if ptr.is_null() {
             None

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -713,6 +713,58 @@ mod tests {
     }
 
     #[test]
+    fn test_get_block_tree_entry() {
+        let (context, temp_dir) = testing_setup();
+
+        let chainman = setup_chainman_with_blocks(&context, &temp_dir).unwrap();
+
+        let chain = chainman.active_chain();
+        let tip = chain.tip();
+        let tip_hash = BlockHash::from(tip.block_hash().to_bytes());
+
+        let entry = chainman.get_block_tree_entry(&tip_hash).unwrap();
+        assert_eq!(entry.height(), tip.height());
+        assert_eq!(entry.block_hash(), tip.block_hash());
+
+        let zero_hash = BlockHash::from([0u8; 32]);
+        assert!(chainman.get_block_tree_entry(&zero_hash).is_none());
+
+        let unknown_hash = BlockHash::from([0xab; 32]);
+        assert!(chainman.get_block_tree_entry(&unknown_hash).is_none());
+
+        let mut flipped_bytes = tip.block_hash().to_bytes();
+        flipped_bytes[0] ^= 1;
+        let flipped_hash = BlockHash::from(flipped_bytes);
+        assert!(chainman.get_block_tree_entry(&flipped_hash).is_none());
+    }
+
+    #[test]
+    fn test_get_block_tree_entry_resolves_every_block() {
+        let (context, temp_dir) = testing_setup();
+
+        let chainman = setup_chainman_with_blocks(&context, &temp_dir).unwrap();
+
+        let chain = chainman.active_chain();
+
+        let mut visited = 0;
+        let mut current = Some(chain.tip());
+
+        while let Some(entry) = current {
+            let hash = BlockHash::from(entry.block_hash().to_bytes());
+            let found = chainman.get_block_tree_entry(&hash).unwrap();
+
+            assert_eq!(found.height(), entry.height());
+            assert_eq!(found.block_hash(), entry.block_hash());
+
+            visited += 1;
+            current = entry.prev();
+        }
+
+        assert!(visited > 1);
+        assert_eq!(visited, chain.height() + 1);
+    }
+
+    #[test]
     fn test_block_transactions_iterator() {
         let block_data = read_block_data();
 


### PR DESCRIPTION
`BlockHash` is a handle wrapper around a `*mut btck_BlockHash`, but the call site cast the address of the wrapper rather than passing the handle it owns. Dereferencing one level short, C read that pointer value where it expected 32 hash bytes, matched nothing in the block index and returned null, which maps to `None`. It fails silently because the address is valid readable memory, and `None` looks the same as an honest miss.

The fix uses the existing accessor, matching every other FFI call in the crate:

```rust
btck_chainstate_manager_get_block_tree_entry_by_hash(self.inner, block_hash.as_ptr())
```
Adds regression tests. One resolves the active chain tip by its own hash and checks that an all-zero hash, an unknown hash, and the tip's hash with one bit flipped all miss. The other walks the chain from tip to genesis and asserts every block resolves to itself, so a lookup returning a fixed entry fails too.

There is no API change as the function returns what it already documented.

Closes #212